### PR TITLE
Migrate loctool sample apps from the ilib-loctool-samples repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ node_modules/
 
 # Code coverage
 coverage/
+
+# Samples
+resources/
+testfiles/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Plugins are optimized for the webOS platform.
 * ilib-loctool-webos-dart: [Dart](https://docs.fileformat.com/programming/dart/) filetype handler.
 * ilib-lint-webos: provides the ability to parse webOS xliff files and provides rules to check.
 * ilib-loctool-webos-dist: for the purpose of distribution for webOS platform.
+* samples-loctool: sample apps written for each app type to validate the webOS loctool plugins.
 
 ## License
 This project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "coverage:ci:affected": "turbo coverage --concurrency=5 --affected",
     "doc": "turbo doc",
     "release": "pnpm build && pnpm changeset publish",
-    "sampleAppTest": "turbo sampleAppTest",
+    "testSampleApp": "turbo testSampleApp",
     "cleanOutput": "turbo cleanOutput"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "coverage:affected": "turbo coverage --affected",
     "coverage:ci:affected": "turbo coverage --concurrency=5 --affected",
     "doc": "turbo doc",
-    "release": "pnpm build && pnpm changeset publish"
+    "release": "pnpm build && pnpm changeset publish",
+    "sampleAppTest": "turbo sampleAppTest"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "coverage:ci:affected": "turbo coverage --concurrency=5 --affected",
     "doc": "turbo doc",
     "release": "pnpm build && pnpm changeset publish",
-    "sampleAppTest": "turbo sampleAppTest"
+    "sampleAppTest": "turbo sampleAppTest",
+    "cleanOutput": "turbo cleanOutput"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/ilib-lint-webos/package.json
+++ b/packages/ilib-lint-webos/package.json
@@ -53,7 +53,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/.bin/jest -i",
+        "debug": "LANG=en_US.UTF8 node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d src test",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilibLint.md ; npm run doc:html",
         "doc:html": "jsdoc -c jsdoc.json"

--- a/packages/ilib-loctool-webos-c/package.json
+++ b/packages/ilib-loctool-webos-c/package.json
@@ -42,7 +42,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-cpp/package.json
+++ b/packages/ilib-loctool-webos-cpp/package.json
@@ -43,7 +43,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-dart/package.json
+++ b/packages/ilib-loctool-webos-dart/package.json
@@ -42,7 +42,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-javascript/package.json
+++ b/packages/ilib-loctool-webos-javascript/package.json
@@ -42,7 +42,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-json-resource/package.json
+++ b/packages/ilib-loctool-webos-json-resource/package.json
@@ -44,7 +44,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-json/package.json
+++ b/packages/ilib-loctool-webos-json/package.json
@@ -41,7 +41,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-qml/package.json
+++ b/packages/ilib-loctool-webos-qml/package.json
@@ -42,7 +42,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/ilib-loctool-webos-ts-resource/package.json
+++ b/packages/ilib-loctool-webos-ts-resource/package.json
@@ -43,7 +43,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/.bin/jest -i",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "engines": {

--- a/packages/samples-loctool/webos-c/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-c/common/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-c/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-c/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-c/common/fr-CA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-c/common/fr-FR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/ja-JP.xliff
+++ b/packages/samples-loctool/webos-c/common/ja-JP.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 時刻設定</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] パスワードを入力してください。</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-c/common/ko-KR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] 비밀번호를 입력해 주세요.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/package.json
+++ b/packages/samples-loctool/webos-c/package.json
@@ -11,9 +11,9 @@
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cstrings.json --plugins webos-c -l en-US,en-AU,en-GB,es-CO,es-ES,fr-CA,fr-FR,ko-KR,ja-JP --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB --projectId sample-webos-c",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-c -l en-US,en-AU,en-GB,es-CO,es-ES,fr-CA,fr-FR,ko-KR,ja-JP --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB --projectId sample-webos-c",
         "clean": "rm -rf *.xliff resources",
-        "sample-test": "node test/testResources.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "sampleAppTest": "pnpm test:all",
+        "run-test": "node test/testResources.js",
+        "execute-all": "npm-run-all clean loc run-test",
+        "testSampleApp": "pnpm execute-all",
         "cleanOutput": "rm -rf *.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-c/package.json
+++ b/packages/samples-loctool/webos-c/package.json
@@ -1,0 +1,27 @@
+{
+    "private": true,
+    "name": "sample-webos-c",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
+        "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cstrings.json --plugins webos-c -l en-US,en-AU,en-GB,es-CO,es-ES,fr-CA,fr-FR,ko-KR,ja-JP --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB --projectId sample-webos-c",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-c -l en-US,en-AU,en-GB,es-CO,es-ES,fr-CA,fr-FR,ko-KR,ja-JP --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB --projectId sample-webos-c",
+        "clean": "rm -rf *.xliff resources",
+        "sample-test": "node test/testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf *.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-c": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.1"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-c/package.json
+++ b/packages/samples-loctool/webos-c/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-c",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {

--- a/packages/samples-loctool/webos-c/project.json
+++ b/packages/samples-loctool/webos-c/project.json
@@ -1,0 +1,48 @@
+{
+    "name": "sample-webos-c",
+    "id": "sample-webos-c",
+    "projectType": "webos-c",
+    "sourceLocale": "en-KR",
+    "pseudoLocale": {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified"
+    },
+    "resourceDirs": {
+        "json":"resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-json-resource"
+    },
+    "plugins": [
+        "ilib-loctool-webos-c"
+    ],
+    "excludes": [
+        ".*",
+        "test",
+        "xliffs",
+        "common",
+        "resources"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "en-US",
+            "en-AU",
+            "en-GB",
+            "es-CO",
+            "es-ES",
+            "fr-CA",
+            "fr-FR",
+            "ko-KR",
+            "ja-JP"
+        ],
+        "resourceFileNames": {
+            "c": "cstrings.json"
+        },
+        "webos": {
+            "commonXliff": "./common"
+        }
+    }
+}

--- a/packages/samples-loctool/webos-c/src/a_localize.c
+++ b/packages/samples-loctool/webos-c/src/a_localize.c
@@ -1,0 +1,68 @@
+
+/** @file a_localize.c
+*/
+
+#include "a_localize.h"
+
+const char* file = "cstrings.json";
+ResBundleC* _gResBundle = NULL;
+
+const char* xpa_localize_getButtonLabel(BUTTON_LABEL_TYPE button)
+{
+    char* localeString = NULL;
+    switch (button)
+    {
+        case BUTTON_LABEL_TYPE_NO:
+        {
+            if (_gResBundle != NULL)
+            {
+                localeString = (char*) resBundle_getLocString(_gResBundle, "No"); // i18n
+                STR_NCPY(_gAlertButton_NO, localeString, LABEL_LEN);
+                STR_FREE(localeString);
+            }
+            return _gAlertButton_NO;
+        }
+s        case BUTTON_LABEL_TYPE_YES:
+        {
+            if (_gResBundle != NULL)
+            {
+                localeString = (char*) resBundle_getLocString(_gResBundle, "Yes"); // i18n
+                STR_NCPY(_gAlertButton_YES, localeString, LABEL_LEN);
+                STR_FREE(localeString);
+            }
+            return _gAlertButton_YES;
+        }
+        case BUTTON_LABEL_TYPE_OK:
+        {
+            if(_gResBundle != NULL)
+            {
+                localeString = (char*) resBundle_getLocString(_gResBundle, "OK"); // i18n
+                STR_NCPY(_gAlertButton_OK, localeString, LABEL_LEN);
+                STR_FREE(localeString);
+            }
+            return _gAlertButton_OK;
+        }
+        case BUTTON_LABEL_TYPE_CANCEL:
+        {
+            if(_gResBundle != NULL)
+            {
+                localeString = (char*) resBundle_getLocString(_gResBundle, "Cancel"); // i18n
+                STR_NCPY(_gAlertButton_CANCEL, localeString, LABEL_LEN);
+                STR_FREE(localeString);
+            }
+            return _gAlertButton_CANCEL;
+        }
+        case BUTTON_LABEL_TYPE_AGREE:
+        {
+            if(_gResBundle != NULL)
+            {
+                localeString = (char*) resBundle_getLocString(_gResBundle, "Agree"); // i18n
+                STR_NCPY(_gAlertButton_AGREE, localeString, LABEL_LEN);
+                STR_FREE(localeString);
+            }
+            return _gAlertButton_CANCEL;
+        }
+        default:
+            return "UNKNOWN";
+    }
+}

--- a/packages/samples-loctool/webos-c/src/list.c
+++ b/packages/samples-loctool/webos-c/src/list.c
@@ -1,0 +1,13 @@
+char *localized_string = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Ivory Coast");
+char *localized_string2 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Programme");
+char *localized_string3 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Sound Out");
+char *localized_string4 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "TV Program Locks");
+char *localized_string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Service Area Zip Code");
+char *localized_string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Time Settings");
+char *localized_string7 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Please enter password.");
+char *localized_string8 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Others");
+char *localized_string9 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Ivory Coast");
+char *localized_string10 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Game Optimizer");
+char *localized_string11= (gchar*)resBundle_getLocString(_g_res_bundle_object, "HDMI Deep Color");
+char *localized_string12 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Exit");
+char *localized_string13 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Do you want to change the settings from \'Digital Sound Output\' to \'Pass Through\' to minimize audio delay while playing game?");

--- a/packages/samples-loctool/webos-c/test/testResources.js
+++ b/packages/samples-loctool/webos-c/test/testResources.js
@@ -1,0 +1,179 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2022-2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** `Run testResources.js` file *****");
+
+function testkoKR(){
+    var loadData = loadJSON("ko/cstrings.json");
+    var result1 = loadData["No"];
+    var result2 = loadData["OK"];
+    var result3 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+                  
+    logResults(arguments.callee.name, "아니오", result1);
+    logResults(arguments.callee.name, "확인", result2);
+    logResults(arguments.callee.name, "'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?", result3);
+}
+
+function testenUS(){
+    var loadData = loadJSON("cstrings.json");
+    var result1 = loadData["Ivory Coast"];
+    var result2 = loadData["Programme"];
+
+    logResults(arguments.callee.name, "Côte d’Ivoire", result1);
+    logResults(arguments.callee.name, "Channel", result2);
+}
+
+function testenAU(){
+    var loadData = loadJSON("en/AU/cstrings.json");
+    var result1 = loadData["Service Area Zip Code"];
+    var result2 = loadData["TV Program Locks"];
+    var result3 = loadData["Programme"];
+    //common data
+    var result4 = loadData["Game Optimizer"];
+    var result5 = loadData["HDMI Deep Color"]
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Game Optimiser", result4);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result5);
+
+    var existKey = isExistKey("en/AU/cstrings.json", "Programme");
+    var existKey2 = isExistKey("en/AU/cstrings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testenGB(){
+    var loadData = loadJSON("en/GB/cstrings.json");
+    var result1 = loadData["Service Area Zip Code"];
+    var result2 = loadData["TV Program Locks"];
+    var result3 = loadData["Programme"];
+    //common data
+    var result4 = loadData["Game Optimizer"];
+    var result5 = loadData["HDMI Deep Color"];
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Game Optimiser", result4);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result5);
+
+    var existKey = isExistKey("en/GB/cstrings.json", "Programme");
+    var existKey2 = isExistKey("en/GB/cstrings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testfrCA(){
+    var loadData = loadJSON("fr/cstrings.json");
+    var result1 = loadData["Agree"];
+    var result2 = loadData["Programme"];
+    var result3 = loadData["Others"];
+    var result4 = loadData["Exit"];
+    var result5 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+
+    logResults(arguments.callee.name, "D’accord", result1);
+    logResults(arguments.callee.name, "Programme", result2);
+    logResults(arguments.callee.name, "Autres", result3);
+    logResults(arguments.callee.name, "Quitter", result4);
+    logResults(arguments.callee.name, "Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?", result5);
+}
+
+function testfrFR(){
+    var loadData = loadJSON("fr/FR/cstrings.json");
+    var result1 = loadData["Agree"];
+    var result2 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+    var existKey = isExistKey("fr/FR/cstrings.json", "Others");
+    var existKey2 = isExistKey("fr/FR/cstrings.json", "Exit");
+    
+    logResults(arguments.callee.name, "J'accepte", result1);
+    logResults(arguments.callee.name, "Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?", result2);
+    logResults(arguments.callee.name, false, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testesES(){
+    var loadData = loadJSON("es/ES/cstrings.json");
+    var result1 = loadData["Sound Out"];
+    var result2 = loadData["OK"];
+    var existKey = isExistKey("es/ES/cstrings.json", "OK");
+    logResults(arguments.callee.name, "Salida de sonido", result1);
+    logResults(arguments.callee.name, "OK", result2);
+    logResults(arguments.callee.name, true, existKey);
+}
+
+function testesCO(){
+    var loadData = loadJSON("es/cstrings.json");
+    var result1 = loadData["Sound Out"];
+    var result2 = loadData["OK"];
+    logResults(arguments.callee.name, "Salida de Audio", result1);
+    logResults(arguments.callee.name, "Aceptar", result2);
+}
+
+function testjaJP(){
+    var loadData = loadJSON("ja/cstrings.json");
+    var result1 = loadData["No"];
+    var result2 = loadData["OK"];
+    logResults(arguments.callee.name, "いいえ", result1);
+    logResults(arguments.callee.name, "確認", result2);
+}
+
+testkoKR();
+testenUS();
+testenAU();
+testenGB();
+testfrCA();
+testfrFR();
+testesES();
+testesCO();
+testjaJP();

--- a/packages/samples-loctool/webos-c/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/en-GB.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/en-US.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Channel</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-c">
+    <group id="sample-webos-js_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-c">
+    <group id="sample-webos-js_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/fr-CA.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>D’accord</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/fr-FR.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>J'accepte</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/ja-JP.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>No</source>
+          <target>いいえ</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Yes</source>
+          <target>はい</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>OK</source>
+          <target>確認</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-c/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/ko-KR.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-c_f1" original="sample-webos-c">
+    <group id="sample-webos-c_g1" name="c">
+      <unit id="1">
+        <segment>
+          <source>No</source>
+          <target>아니오</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Yes</source>
+          <target>예</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>OK</source>
+          <target>확인</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Time Settings</source>
+          <target>[App] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-cpp/common/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-cpp/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-cpp/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-cpp/common/fr-CA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-cpp/common/fr-FR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/ja-JP.xliff
+++ b/packages/samples-loctool/webos-cpp/common/ja-JP.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 時刻設定</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] パスワードを入力してください。</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-cpp/common/ko-KR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] 비밀번호를 입력해 주세요.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/package.json
+++ b/packages/samples-loctool/webos-cpp/package.json
@@ -11,9 +11,9 @@
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cppstrings.json --plugins webos-cpp -l en-AU,en-GB,ko-KR,es-CO,es-ES,fr-CA,fr-FR,ko-KR --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --projectId sample-webos-cpp",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-cpp -l en-AU,en-GB,ko-KR,es-CO,es-ES,ko-KR --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --projectId sample-webos-cpp",
         "clean": "rm -rf *.xliff resources",
-        "sample-test": "node test/testResources.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "sampleAppTest": "pnpm test:all",
+        "run-test": "node test/testResources.js",
+        "execute-all": "npm-run-all clean loc run-test",
+        "testSampleApp": "pnpm execute-all",
         "cleanOutput": "rm -rf *.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-cpp/package.json
+++ b/packages/samples-loctool/webos-cpp/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-cpp",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {

--- a/packages/samples-loctool/webos-cpp/package.json
+++ b/packages/samples-loctool/webos-cpp/package.json
@@ -1,0 +1,27 @@
+{
+    "private": true,
+    "name": "sample-webos-cpp",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB",
+        "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --resourceFileNames json=cppstrings.json --plugins webos-cpp -l en-AU,en-GB,ko-KR,es-CO,es-ES,fr-CA,fr-FR,ko-KR --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --projectId sample-webos-cpp",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-cpp -l en-AU,en-GB,ko-KR,es-CO,es-ES,ko-KR --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --projectId sample-webos-cpp",
+        "clean": "rm -rf *.xliff resources",
+        "sample-test": "node test/testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf *.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-cpp": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.1"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-cpp/project.json
+++ b/packages/samples-loctool/webos-cpp/project.json
@@ -1,0 +1,48 @@
+{
+    "name": "sample-webos-cpp",
+    "id": "sample-webos-cpp",
+    "projectType": "webos-cpp",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified"
+    },
+    "resourceDirs": {
+        "json":"resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-json-resource"
+    },
+    "plugins": [
+        "ilib-loctool-webos-cpp"
+    ],
+    "excludes": [
+        ".*",
+        "test",
+        "xliffs",
+        "common",
+        "resources"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "en-AU",
+            "en-GB",
+            "en-US",
+            "es-CO",
+            "es-ES",
+            "ja-JP",
+            "ko-KR",
+            "fr-CA",
+            "fr-FR"
+        ],
+        "resourceFileNames": {
+            "cpp": "cppstrings.json"
+        },
+        "webos": {
+            "commonXliff": "./common"
+        }
+    }
+}

--- a/packages/samples-loctool/webos-cpp/src/test.cpp
+++ b/packages/samples-loctool/webos-cpp/src/test.cpp
@@ -1,0 +1,44 @@
+/* @@@LICENSE
+*/
+
+bool get_checking_update(AppLaunchingItem prelaunching_item,)
+{
+    if(UPDATE_TYPE_OPTIONAL == update_type)
+    {
+        // (update button)
+        std::string update_label        = ResBundleAdaptor::instance().getLocString("Update"); // i18n
+        // (launch button)
+        std::string launch_label        = ResBundleAdaptor::instance().getLocString("Launch"); // i18n
+        // (cancel button)
+        std::string cancel_label        = ResBundleAdaptor::instance().getLocString("Cancel"); // i18n
+        std::string sound_label        = ResBundleAdaptor::instance().getLocString("Sound Out");
+        std::string other_label        = ResBundleAdaptor::instance().getLocString("Others");
+        std::string ivory_label        = ResBundleAdaptor::instance().getLocString("Ivory Coast");
+        std::string game_label        = ResBundleAdaptor::instance().getLocString("Game Optimizer");
+        std::string hdmi_label        = ResBundleAdaptor::instance().getLocString("HDMI Deep Color");
+
+    }
+    else // required
+    {
+        description = ResBundleAdaptor::instance().getLocString("You must update this app to launch it."); // i18n
+        // (yes button)
+        std::string yes_label          = ResBundleAdaptor::instance().getLocString("Yes"); // i18n
+        // (no button)
+        std::string no_label           = ResBundleAdaptor::instance().getLocString("No"); // i18n
+        std::string exit_label           = ResBundleAdaptor::instance().getLocString("Exit");
+        std::string ok_label           = ResBundleAdaptor::instance().getLocString("OK");
+        std::string agree_label        = ResBundleAdaptor::instance().getLocString("Agree");
+        std::string program_label      = ResBundleAdaptor::instance().getLocString("Programme");
+        std::string ivory_label        = ResBundleAdaptor::instance().getLocString("Ivory Coast");
+        std::string test1_label        = ResBundleAdaptor::instance().getLocString("TV Program Locks");
+        std::string test2_label        = ResBundleAdaptor::instance().getLocString("Service Area Zip Code");
+        std::string test3_label        = ResBundleAdaptor::instance().getLocString("Time Settings");
+        std::string test4_label        = ResBundleAdaptor::instance().getLocString("Please enter password.");
+        // Layout: [yes] [no]
+        buttons.append(yes_btn);
+        buttons.append(no_btn);
+    }
+    if (pResBundle) {
+        trans1 = pResBundle->getLocString("Do you want to change the settings from \'Digital Sound Output\' to \'Pass Through\' to minimize audio delay while playing game?");
+    }
+}

--- a/packages/samples-loctool/webos-cpp/test/testResources.js
+++ b/packages/samples-loctool/webos-cpp/test/testResources.js
@@ -1,0 +1,172 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2022-2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** `Run testResources.js` file *****");
+
+function testkoKR(){
+    var loadData = loadJSON("ko/cppstrings.json");
+    var result1 = loadData["No"];
+    var result2 = loadData["Update"];
+    var result3 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+                  
+    logResults(arguments.callee.name, "아니오", result1);
+    logResults(arguments.callee.name, "업데이트", result2);
+    logResults(arguments.callee.name, "'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?", result3);
+}
+
+function testenUS(){
+    var loadData = loadJSON("cppstrings.json");
+    var result1 = loadData["Ivory Coast"];
+    var result2 = loadData["Programme"];
+
+    logResults(arguments.callee.name, "Côte d’Ivoire", result1);
+    logResults(arguments.callee.name, "Channel", result2);
+}
+
+function testenAU(){
+    var loadData = loadJSON("en/AU/cppstrings.json");
+    var result1 = loadData["Service Area Zip Code"];
+    var result2 = loadData["TV Program Locks"];
+    var result3 = loadData["Programme"];
+    //common data
+    var result4 = loadData["Game Optimizer"];
+    var result5 = loadData["HDMI Deep Color"];
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Game Optimiser", result4);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result5);
+
+    var existKey = isExistKey("en/AU/cppstrings.json", "Programme");
+    var existKey2 = isExistKey("en/AU/cppstrings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testenGB(){
+    var loadData = loadJSON("en/GB/cppstrings.json");
+    var result1 = loadData["Service Area Zip Code"];
+    var result2 = loadData["TV Program Locks"];
+    var result3 = loadData["Programme"];
+    //common data
+    var result4 = loadData["Game Optimizer"];
+    var result5 = loadData["HDMI Deep Color"];
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Game Optimiser", result4);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result5);
+
+    var existKey = isExistKey("en/GB/cppstrings.json", "Programme");
+    var existKey2 = isExistKey("en/GB/cppstrings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testfrCA(){
+    var loadData = loadJSON("fr/cppstrings.json");
+    var result1 = loadData["Agree"];
+    var result2 = loadData["Programme"];
+    var result3 = loadData["Others"];
+    var result5 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+    //common data
+    var result4 = loadData["Exit"];
+
+    logResults(arguments.callee.name, "D’accord", result1);
+    logResults(arguments.callee.name, "Programme", result2);
+    logResults(arguments.callee.name, "Autres", result3);
+    logResults(arguments.callee.name, "Quitter", result4);
+    logResults(arguments.callee.name, "Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?", result5);
+}
+
+function testfrFR(){
+    var loadData = loadJSON("fr/FR/cppstrings.json");
+    var result1 = loadData["Agree"];
+    var result2 = loadData["Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?"];
+    var existKey = isExistKey("fr/FR/cppstrings.json", "Others");
+    var existKey2 = isExistKey("fr/FR/cppstrings.json", "Exit");
+    
+    logResults(arguments.callee.name, "J'accepte", result1);
+    logResults(arguments.callee.name, "Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?", result2);
+    logResults(arguments.callee.name, false, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testesES(){
+    var loadData = loadJSON("es/ES/cppstrings.json");
+    var result1 = loadData["Sound Out"];
+    var result2 = loadData["OK"];
+    logResults(arguments.callee.name, "Salida de sonido", result1);
+    logResults(arguments.callee.name, "OK", result2);
+
+    var existKey = isExistKey("es/ES/cppstrings.json", "OK");
+    logResults(arguments.callee.name, true, existKey);
+}
+
+function testesCO(){
+    var loadData = loadJSON("es/cppstrings.json");
+    var result1 = loadData["Sound Out"];
+    var result2 = loadData["OK"];
+    logResults(arguments.callee.name, "Salida de Audio", result1);
+    logResults(arguments.callee.name, "Aceptar", result2);
+}
+
+testkoKR();
+testenUS();
+testenAU();
+testenGB();
+testfrCA();
+testfrFR();
+testesES();
+testesCO();

--- a/packages/samples-loctool/webos-cpp/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/en-GB.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/en-US.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Channel</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-cpp">
+    <group id="sample-webos-js_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-cpp">
+    <group id="sample-webos-js_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/fr-CA.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>D’accord</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Voulez-vous changer les paramètres de « Sortie audio numérique » à « Passage » pour minimiser le délai audio pendant les jeux?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/fr-FR.xliff
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Update</source>
+          <target>Mettez à jour</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Cancel</source>
+          <target>Annuler</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Yes</source>
+          <target>Oui</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>No</source>
+          <target>Non</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>Agree</source>
+          <target>J'accepte</target>
+        </segment>
+      </unit>
+      <unit id="8">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>Souhaitez-vous modifier les paramètres de « Sortie audio numérique » en « Interconnexion » pour limiter le décalage audio pendant le jeu ?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-cpp/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/ko-KR.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
+    <group id="sample-webos-cpp_g1" name="cpp">
+      <unit id="1">
+        <segment>
+          <source>Update</source>
+          <target>업데이트</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Cancel</source>
+          <target>취소</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Yes</source>
+          <target>예</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>No</source>
+          <target>아니오</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Time Settings</source>
+          <target>[App] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>Do you want to change the settings from 'Digital Sound Output' to 'Pass Through' to minimize audio delay while playing game?</source>
+          <target>'디지털 음향 내보내기' 를 오디오 지연을 최소화하여 게임을 즐길 수 있는 'Pass Through'로 변경할까요?</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/appinfo.json
+++ b/packages/samples-loctool/webos-dart/appinfo.json
@@ -1,0 +1,19 @@
+{
+    "id": "com.app.livetv",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Live TV",
+    "icon": "icon.png",
+    "uiRevision": 2,
+    "transparent": true,
+    "visible": false,
+    "lockable": false,
+    "trustLevel": "trusted",
+    "accessibility": {
+        "supportsAudioGuidance": true
+    },
+    "voiceControl": "manual",
+    "v8SnapshotFile": "snapshot_blob.bin",
+    "vendor": "test"
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/en.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/en.json
@@ -1,0 +1,8 @@
+{
+    "App List": "App List",
+    "App Rating": "App Rating",
+    "Back button": "Back button",
+    "Delete All": "Delete All",
+    "Search_all": "Search",
+    "{appName} app cannot be deleted.": "{appName} app cannot be deleted."
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/es.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/es.json
@@ -1,0 +1,14 @@
+{
+    "App List": "Lista de Aplicaciones",
+    "App Rating": "Clasificación de Aplicación",
+    "Back button": "Botón regresar",
+    "Delete All": "Eliminar Todo",
+    "OK": "Aceptar",
+    "Search_all": "Buscar",
+    "plural.demo": {
+        "zero": "Por favor, comience a presionar el botón 'más'.",
+        "one": "Has pulsado el botón una vez.",
+        "two": "Has pulsado el botón dos veces.",
+        "other": "Ha pulsado el botón {num} veces."
+    }
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/es_ES.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/es_ES.json
@@ -1,0 +1,8 @@
+{
+    "App List": "Lista de aplicaciones",
+    "App Rating": "Clasificación de la aplicación",
+    "Back button": "Botón atrás",
+    "Delete All": "Eliminar todo",
+    "OK": "OK",
+    "Search_all": "Búsqueda"
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/fluttermanifest.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/fluttermanifest.json
@@ -1,0 +1,14 @@
+{
+    "files": [
+        "en.json",
+        "es.json",
+        "es_ES.json",
+        "fr.json",
+        "fr_FR.json",
+        "ja.json",
+        "ko.json",
+        "sl.json"
+    ],
+    "l10n_timestamp": "1741066842084",
+    "generated": true
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/fr.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/fr.json
@@ -1,0 +1,7 @@
+{
+    "App List": "Liste des applications",
+    "App Rating": "Évaluation de l'application",
+    "Back button": "Bouton Retour",
+    "Delete All": "Tout supprimer",
+    "Search_all": "Rechercher"
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/fr_FR.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/fr_FR.json
@@ -1,0 +1,7 @@
+{
+    "App List": "Liste des applications",
+    "App Rating": "Évaluation de l'application",
+    "Back button": "Bouton Retour",
+    "Delete All": "Tout supprimer",
+    "Search_all": "Recherche"
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/ja.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/ja.json
@@ -1,0 +1,7 @@
+{
+    "App List": "アプリリスト",
+    "App Rating": "アプリの評価",
+    "Back button": "[戻る]ボタン",
+    "Delete All": "すべて削除",
+    "Search_all": "検索"
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/ko.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/ko.json
@@ -1,0 +1,8 @@
+{
+    "App List": "앱 목록",
+    "App Rating": "앱 등급",
+    "Back button": "이전 버튼",
+    "Delete All": "모두 삭제",
+    "Search_all": "통합 검색",
+    "{appName} app cannot be deleted.": "{appName}앱은 삭제될 수 없습니다."
+}

--- a/packages/samples-loctool/webos-dart/assets/i18n/sl.json
+++ b/packages/samples-loctool/webos-dart/assets/i18n/sl.json
@@ -1,0 +1,9 @@
+{
+    "1#At least 1 letter|#At least {num} letters": {
+        "one": "Vsaj {num} znak",
+        "two": "Vsaj {num} znaka",
+        "few": "Vsaj {num} znake",
+        "other": "Vsaj {num} znakov"
+    },
+    "Search_all": "Iskanje"
+}

--- a/packages/samples-loctool/webos-dart/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-dart/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-dart/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -1,0 +1,26 @@
+{
+    "private": true,
+    "name": "sample-webos-dart",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
+        "clean": "rm -rf *.xliff assets resources",
+        "sample-test": "node test/testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf sample-webos-*.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-dart": "workspace:*",
+        "ilib-loctool-webos-json": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.1"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -9,9 +9,9 @@
         "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
         "clean": "rm -rf *.xliff assets resources",
-        "sample-test": "node test/testResources.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "sampleAppTest": "pnpm test:all",
+        "run-test": "node test/testResources.js",
+        "execute-all": "npm-run-all clean loc run-test",
+        "testSampleApp": "pnpm execute-all",
         "cleanOutput": "rm -rf sample-webos-*.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-dart",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {

--- a/packages/samples-loctool/webos-dart/project.json
+++ b/packages/samples-loctool/webos-dart/project.json
@@ -1,0 +1,62 @@
+{
+    "name": "sample-webos-dart",
+    "id": "sample-webos-dart",
+    "projectType": "webos-dart",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified",
+        "as-XX" : "debug-font"
+    },
+    "resourceDirs": {
+        "json": "resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-json-resource"
+    },
+    "plugins": [
+        "ilib-loctool-webos-dart",
+        "ilib-loctool-webos-json"
+    ],
+    "excludes": [
+        ".*",
+        "test",
+        "xliffs",
+        "common",
+        "resources",
+        "assets"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "en-US",
+            "es-CO",
+            "es-ES",
+            "fr-CA",
+            "fr-FR",
+            "ja-JP",
+            "ko-KR",
+            "sl-SI"
+        ],
+        "localeMap": {
+            "fr-CA": "fr"
+        },
+        "localeInherit": {
+            "en-CN": "en-GB",
+            "en-AU": "en-GB"
+        },
+        "webos": {
+            "commonXliff": "./common"
+        },
+        "dart": {
+            "disablePseudo": true,
+            "mappings" : {
+                "**/*.dart": {
+                    "template": "[dir]/assets/i18n/[localeUnder].json"
+                }
+            }
+        }
+    }
+}

--- a/packages/samples-loctool/webos-dart/src/msg.dart
+++ b/packages/samples-loctool/webos-dart/src/msg.dart
@@ -1,0 +1,16 @@
+
+translate("Search", key: "Search_all");
+translate("Back button");
+translate("Delete All");
+translate("App List");
+translate("App Rating", args: {"arg1": "music_track"});
+
+translatePlural('plural.demo', _counter);
+translatePlural('1#At least 1 letter|#At least {num} letters', num);
+
+translate("OK");
+
+translate(
+  '{appName} app cannot be deleted.',
+    args: {'appName': 'Settings'}
+    ),

--- a/packages/samples-loctool/webos-dart/test/testResources.js
+++ b/packages/samples-loctool/webos-dart/test/testResources.js
@@ -1,0 +1,191 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "assets/i18n");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** `Run testResources.js` file *****");
+
+function testkoKR(){
+    var loadData = loadJSON("ko.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+    var result6 = loadData["{appName} app cannot be deleted."];
+                  
+    logResults(arguments.callee.name, "앱 목록", result1);
+    logResults(arguments.callee.name, "앱 등급", result2);
+    logResults(arguments.callee.name, "이전 버튼", result3);
+    logResults(arguments.callee.name, "모두 삭제", result4);
+    logResults(arguments.callee.name, "통합 검색", result5);
+    logResults(arguments.callee.name, "{appName}앱은 삭제될 수 없습니다.", result6);
+}
+
+function testfrCA(){
+    var loadData = loadJSON("fr.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+
+    logResults(arguments.callee.name, "Liste des applications", result1);
+    logResults(arguments.callee.name, "Évaluation de l'application", result2);
+    logResults(arguments.callee.name, "Bouton Retour", result3);
+    logResults(arguments.callee.name, "Tout supprimer", result4);
+    logResults(arguments.callee.name, "Rechercher", result5);
+}
+
+function testfrFR(){
+    var loadData = loadJSON("fr_FR.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+
+    logResults(arguments.callee.name, "Liste des applications", result1);
+    logResults(arguments.callee.name, "Évaluation de l'application", result2);
+    logResults(arguments.callee.name, "Bouton Retour", result3);
+    logResults(arguments.callee.name, "Tout supprimer", result4);
+    logResults(arguments.callee.name, "Recherche", result5);
+}
+
+function testesCO(){
+    var loadData = loadJSON("es.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+    var result6 = loadData["OK"];
+    var result7 = loadData["plural.demo"];
+
+    logResults(arguments.callee.name, "Lista de Aplicaciones", result1);
+    logResults(arguments.callee.name, "Clasificación de Aplicación", result2);
+    logResults(arguments.callee.name, "Botón regresar", result3);
+    logResults(arguments.callee.name, "Eliminar Todo", result4);
+    logResults(arguments.callee.name, "Buscar", result5);
+    logResults(arguments.callee.name, "Aceptar", result6);
+    logResults(arguments.callee.name, "Has pulsado el botón una vez.", result7.one);
+    logResults(arguments.callee.name, "Has pulsado el botón dos veces.", result7.two);
+    logResults(arguments.callee.name, "Ha pulsado el botón {num} veces.", result7.other);
+}
+
+function testesES(){
+    var loadData = loadJSON("es_ES.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+    var result6 = loadData["OK"];
+
+    logResults(arguments.callee.name, "Lista de aplicaciones", result1);
+    logResults(arguments.callee.name, "Clasificación de la aplicación", result2);
+    logResults(arguments.callee.name, "Botón atrás", result3);
+    logResults(arguments.callee.name, "Eliminar todo", result4);
+    logResults(arguments.callee.name, "Búsqueda", result5);
+    logResults(arguments.callee.name, "OK", result6);
+}
+
+function testenUS(){
+    var loadData = loadJSON("en.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+    var result6 = loadData["{appName} app cannot be deleted."];
+
+    logResults(arguments.callee.name, "App List", result1);
+    logResults(arguments.callee.name, "App Rating", result2);
+    logResults(arguments.callee.name, "Back button", result3);
+    logResults(arguments.callee.name, "Delete All", result4);
+    logResults(arguments.callee.name, "Search", result5);
+    logResults(arguments.callee.name, "{appName} app cannot be deleted.", result6);
+}
+
+function testjaJP(){
+    var loadData = loadJSON("ja.json");
+    var result1 = loadData["App List"];
+    var result2 = loadData["App Rating"];
+    var result3 = loadData["Back button"];
+    var result4 = loadData["Delete All"];
+    var result5 = loadData["Search_all"];
+
+    logResults(arguments.callee.name, "アプリリスト", result1);
+    logResults(arguments.callee.name, "アプリの評価", result2);
+    logResults(arguments.callee.name, "[戻る]ボタン", result3);
+    logResults(arguments.callee.name, "すべて削除", result4);
+    logResults(arguments.callee.name, "検索", result5);
+}
+
+function testslSI(){
+    var loadData = loadJSON("sl.json");
+    var result1 = loadData["Search_all"];
+    var result2 = loadData["1#At least 1 letter|#At least {num} letters"];
+
+    logResults(arguments.callee.name, "Iskanje", result1);
+    logResults(arguments.callee.name, "Vsaj {num} znak", result2.one);
+    logResults(arguments.callee.name, "Vsaj {num} znaka", result2.two);
+    logResults(arguments.callee.name, "Vsaj {num} znake", result2.few);
+    logResults(arguments.callee.name, "Vsaj {num} znakov", result2.other);
+}
+
+testkoKR();
+testfrCA();
+testfrFR();
+testesES();
+testesCO();
+testenUS();
+testjaJP();
+testslSI();

--- a/packages/samples-loctool/webos-dart/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/en-US.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Search</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>App List</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>App Rating</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>Back button</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>Delete All</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+        <source>{appName} app cannot be deleted.</source>
+        <target>{appName} app cannot be deleted.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Buscar</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>Lista de Aplicaciones</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>Clasificación de Aplicación</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>Botón regresar</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>Eliminar Todo</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>plural.demo</source>
+          <target>0#Por favor, comience a presionar el botón 'más'.|1#Has pulsado el botón una vez.|2#Has pulsado el botón dos veces.|#Ha pulsado el botón {num} veces.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/es-ES.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Búsqueda</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>Lista de aplicaciones</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>Clasificación de la aplicación</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>Botón atrás</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>Eliminar todo</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/fr-CA.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Rechercher</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>Liste des applications</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>Évaluation de l'application</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>Bouton Retour</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>Tout supprimer</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/fr-FR.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Recherche</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>Liste des applications</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>Évaluation de l'application</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>Bouton Retour</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>Tout supprimer</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ja-JP.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>検索</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>アプリリスト</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>アプリの評価</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>[戻る]ボタン</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>すべて削除</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>통합 검색</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>앱 목록</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>App Rating</source>
+          <target>앱 등급</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Back button</source>
+          <target>이전 버튼</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Delete All</source>
+          <target>모두 삭제</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+        <source>{appName} app cannot be deleted.</source>
+        <target>{appName}앱은 삭제될 수 없습니다.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/sl-SI.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/sl-SI.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="sl-SI" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-dart_f1" original="sample-webos-dart">
+    <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1" name="Search_all">
+        <segment>
+          <source>Search</source>
+          <target>Iskanje</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>1#At least 1 letter|#At least {num} letters</source>
+          <target>1#Vsaj {num} znak|2#Vsaj {num} znaka|few#Vsaj {num} znake|#Vsaj {num} znakov</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/.gitignore
+++ b/packages/samples-loctool/webos-js/.gitignore
@@ -1,0 +1,2 @@
+resources
+node_modules

--- a/packages/samples-loctool/webos-js/.gitignore
+++ b/packages/samples-loctool/webos-js/.gitignore
@@ -1,2 +1,0 @@
-resources
-node_modules

--- a/packages/samples-loctool/webos-js/appinfo.json
+++ b/packages/samples-loctool/webos-js/appinfo.json
@@ -1,0 +1,19 @@
+{
+    "id": "sample-webos-js",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Live TV",
+    "icon": "icon.png",
+    "uiRevision": 2,
+    "transparent": true,
+    "visible": false,
+    "lockable": false,
+    "trustLevel": "trusted",
+    "accessibility": {
+        "supportsAudioGuidance": true
+    },
+    "voiceControl": "manual",
+    "v8SnapshotFile": "snapshot_blob.bin",
+    "vendor": "test"
+}

--- a/packages/samples-loctool/webos-js/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-js/common/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-js/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-js/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js/common/fr-CA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js/common/fr-FR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/common/ko-KR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] 비밀번호를 입력해 주세요.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -11,11 +11,11 @@
         "clean": "rm -rf *.xliff resources",
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json  --projectId sample-webos-js -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
-        "sample-test": "node test/testResources.js; node test/testResourceLocalize.js",
-        "test-generate": "node test/testResources.js; node test/testResourceGenerate.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "test-generate:all": "npm-run-all clean loc-generate test-generate",
-        "sampleAppTest": "pnpm test:all test-generate:all",
+        "run-test-generate": "node test/testResources.js; node test/testResourceGenerate.js",
+        "run-test": "node test/testResources.js; node test/testResourceLocalize.js",
+        "execute-all": "npm-run-all clean loc run-test",
+        "execute-generate-all": "npm-run-all clean loc-generate run-test-generate",
+        "testSampleApp": "pnpm execute-all execute-generate-all",
         "cleanOutput": "rm -rf *.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -15,7 +15,8 @@
         "test-generate": "node test/testResources.js; node test/testResourceGenerate.js",
         "test:all": "npm-run-all clean loc sample-test",
         "test-generate:all": "npm-run-all clean loc-generate test-generate",
-        "sampleAppTest": "pnpm test:all test-generate:all"
+        "sampleAppTest": "pnpm test:all test-generate:all",
+        "cleanOutput": "rm -rf *.xliff resources"
     },
     "dependencies": {
         "ilib": "^14.21.0",

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -1,0 +1,30 @@
+{
+    "private": true,
+    "name": "sample-webos-js",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
+        "clean": "rm -rf *.xliff resources",
+        "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json  --projectId sample-webos-js -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
+        "sample-test": "node test/testResources.js; node test/testResourceLocalize.js",
+        "test-generate": "node test/testResources.js; node test/testResourceGenerate.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "test-generate:all": "npm-run-all clean loc-generate test-generate",
+        "sampleAppTest": "pnpm test:all test-generate:all"
+    },
+    "dependencies": {
+        "ilib": "^14.21.0",
+        "ilib-loctool-webos-javascript": "workspace:*",
+        "ilib-loctool-webos-json": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.1"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-js/project.json
+++ b/packages/samples-loctool/webos-js/project.json
@@ -1,0 +1,69 @@
+{
+    "name": "sample-webos-js",
+    "id": "sample-webos-js",
+    "projectType": "custom",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified",
+        "as-XX" : "debug-font"
+    },
+    "resourceDirs": {
+        "json":"resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-json-resource"
+    },
+    "plugins": [
+        "ilib-loctool-webos-javascript",
+        "ilib-loctool-webos-json"
+    ],
+    "excludes": [
+        ".*",
+        "test",
+        "xliffs",
+        "common"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "as-IN",
+            "de-DE",
+            "es-CO",
+            "es-ES",
+            "en-US",
+            "fr-CA",
+            "fr-FR",
+            "ja-JP",
+            "ko-KR",
+            "ko-US",
+            "en-AU",
+            "en-GB"
+        ],
+        "localeMap": {
+            "fr-CA": "fr"
+        },
+        "localeInherit": {
+            "en-CN": "en-GB",
+            "en-AU": "en-GB"
+        },
+        "webos": {
+            "commonXliff": "./common"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                },
+                "**/qcardinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        },
+        "javascript": {
+            "disablePseudo": true
+        }
+    }
+}

--- a/packages/samples-loctool/webos-js/src/msg.js
+++ b/packages/samples-loctool/webos-js/src/msg.js
@@ -1,0 +1,94 @@
+import $L from '@enact/i18n/$L';
+export function findMsgByCode (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Hello'); // i18n : i18n comments
+            break;
+        case 2:
+            msg.reason = $L('Thank you');
+            break;
+        case 3:
+            msg.reason = $L('Congratulation');
+            break;
+        case 4:
+            msg.reason = $L('Antenna NEXTGEN TV');
+            break;
+        case 5:
+            msg.reason = $L('Game Optimizer');
+            break;
+        case 6:
+            msg.reason = $L('HDMI Deep Color');
+            break;
+        case 7:
+            msg.reason = $L('Exit');
+            break;
+        case 8:
+            msg.reason = $L('OK');
+            break;
+        case 9:
+            msg.reason = $L('Restart');
+            break;
+        default:
+            msg.reason = $L('Bye');
+            break;
+    }
+    return msg;
+}
+export function findMsgByCode2 (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Agree');
+            break;
+        case 2:
+            msg.reason = $L('Ivory Coast');
+            break;
+        default:
+            msg.reason = $L('Programme');
+            break;
+    }
+    return msg;
+}
+export function findMsgByCode3 (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Live TV'); // xliff_target: nbsp
+            break;
+        case 2:
+            msg.reason = $L('Space NBSP'); // xliff_source: nbsp
+            break;
+        case 3:
+            msg.reason = $L('To read the Terms and Conditions, go to Settings > Support >            Privacy & Terms.'); // multi-spaces
+            break;
+        case 4:
+            msg.reason = $L('TV Name : '); // xliff_target trim
+            break;
+        case 5:
+            msg.reason = $L('Sound Out');
+            break;
+        case 6:
+            msg.reason = $L('TV Program Locks');
+            break;
+        case 7:
+            msg.reason = $L('Service Area Zip Code');
+            break;
+        case 8:
+            msg.reason = $L('Time Settings');
+            break;
+        case 9:
+            msg.reason = $L('Please enter password.');
+            break;
+        case 10:
+            msg.reason = $L('Others');
+        case 11:
+            $L("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.")
+            break;
+        case 12:
+            $L({key: 'volumeModeHigh', value: 'High' });
+            break;
+        default:
+            msg.reason = $L('MAC Address'); // xliff_target trim
+            break;
+    }
+    return msg;
+}
+

--- a/packages/samples-loctool/webos-js/src/msg2.js
+++ b/packages/samples-loctool/webos-js/src/msg2.js
@@ -1,0 +1,24 @@
+webappResBundle = new ResBundle({
+    basePath: "../resources"
+});
+
+function setButtonsOnPage(layoutCase) {
+    switch (layoutCase) {
+    case 0:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        break;
+    case 1:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("RETRY"), "Retry_Button", dir_tail, onRetryApp);
+        break;
+    case 2:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("SETTINGS"), "Setting_Button", dir_tail, onLaunchGeneralSetting);
+        createButtonOnPage(webappResBundle.getString("RETRY"), "Retry_Button", dir_tail, onRetryApp);
+        break;
+    default:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("CLOSE"), "ExitApp_Button", dir_head, onExitApp);
+        break;
+    }
+}

--- a/packages/samples-loctool/webos-js/test/testResourceGenerate.js
+++ b/packages/samples-loctool/webos-js/test/testResourceGenerate.js
@@ -1,0 +1,55 @@
+/*
+ * testResourcesGenerate.js - test file for `generate` mode output
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var path = require("path");
+
+var ResBundle = require("ilib/lib/ResBundle");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+   
+console.log("\n***** Run `testResourceGenerate.js` file  *****");
+function testkoKR(){
+    var rb = new ResBundle({
+        locale:"ko-KR",
+        basePath : defaultRSPath
+    });
+    // common data path.
+    var result1 = rb.getString("Please enter password.").toString();
+    logResults(arguments.callee.name, "Please enter password.", result1);
+}
+
+function testjaJP(){
+    var rb = new ResBundle({
+        locale:"ja-JP",
+        basePath : defaultRSPath
+    });
+
+    // fyi. https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/34
+    var result1 = rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString();
+    logResults(arguments.callee.name, "To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.", result1);
+}
+
+testkoKR();
+testjaJP();

--- a/packages/samples-loctool/webos-js/test/testResourceLocalize.js
+++ b/packages/samples-loctool/webos-js/test/testResourceLocalize.js
@@ -1,0 +1,154 @@
+/*
+ * testResourcesLocalize.js - test file for normal `localize` mode output
+ *
+ * Copyright © 2022-2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var path = require("path");
+var fs = require("fs");
+var ResBundle = require("ilib/lib/ResBundle");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)){
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** Run `testResourceLocalize.js` file  *****");
+function testkoKR(){
+    var rb = new ResBundle({
+        locale:"ko-KR",
+        basePath : defaultRSPath
+    });
+    // common data path.
+    var result1 = rb.getString("Please enter password.").toString();
+    logResults(arguments.callee.name, "[common] 비밀번호를 입력해 주세요.", result1);
+}
+
+function testjaJP(){
+    var rb = new ResBundle({
+        locale:"ja-JP",
+        basePath : defaultRSPath
+    });
+
+    // fyi. https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/34
+    var result1 = rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString();
+    logResults(arguments.callee.name, "利用規約を読むには、設定 > サポート > 利用規約 & 法的情報に移動します。", result1);
+}
+
+function testenGB(){
+    var rb = new ResBundle({
+        locale:"en-GB",
+        basePath : defaultRSPath
+    });
+    // common data's locale Inheritence
+    var result1 = rb.getString("Game Optimizer").toString();
+    var result2 = rb.getString("HDMI Deep Color").toString();
+    //multi-space
+    var result3 = rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString();
+
+    logResults(arguments.callee.name, "Game Optimiser", result1);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+    logResults(arguments.callee.name, "Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.", result3);
+}
+
+function testenAU(){
+    var rb = new ResBundle({
+        locale:"en-AU",
+        basePath : defaultRSPath
+    });
+    // common data's locale Inheritence
+    var result1 = rb.getString("Game Optimizer").toString();
+    var result2 = rb.getString("HDMI Deep Color").toString();
+    //multi-space
+    var result3 = rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString();
+
+    logResults(arguments.callee.name, "Game Optimiser", result1);
+    logResults(arguments.callee.name, "HDMI Deep Colour", result2);
+    logResults(arguments.callee.name, "Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.", result3);
+}
+
+function testfrCA(){
+    var rb = new ResBundle({
+        locale:"fr-CA",
+        basePath : defaultRSPath
+    });
+    // common data
+    var result1 = rb.getString("Exit").toString();
+    logResults(arguments.callee.name, "Quitter", result1);
+
+    var existKey = isExistKey("fr/strings.json", "Exit");
+    logResults(arguments.callee.name, true, existKey);
+}
+
+function testfrFR(){
+    var rb = new ResBundle({
+        locale:"fr-FR",
+        basePath : defaultRSPath
+    });
+    // common data
+    var result1 = rb.getString("Exit").toString();
+    logResults(arguments.callee.name, "Quitter", result1);
+
+    var existKey = isExistKey("fr/FR/strings.json", "Exit");
+    logResults(arguments.callee.name, false, existKey);
+}
+
+function testesCO(){
+    var rb = new ResBundle({
+        locale:"es-CO",
+        basePath : defaultRSPath
+    });
+    // common data
+    var result1 = rb.getString("OK").toString();
+    logResults(arguments.callee.name, "Aceptar", result1);
+}
+
+function testesES(){
+    var rb = new ResBundle({
+        locale:"es-ES",
+        basePath : defaultRSPath
+    });
+    // common data
+    var result1 = rb.getString("OK").toString();
+    logResults(arguments.callee.name, "OK", result1);
+
+    var existKey = isExistKey("es/ES/strings.json", "OK");
+    logResults(arguments.callee.name, true, existKey);
+
+}
+
+testkoKR();
+testjaJP();
+testenGB();
+testenAU();
+testfrCA();
+testfrFR();
+testesCO();
+testesES();

--- a/packages/samples-loctool/webos-js/test/testResources.js
+++ b/packages/samples-loctool/webos-js/test/testResources.js
@@ -1,0 +1,215 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2022-2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+
+var ResBundle = require("ilib/lib/ResBundle");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)){
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** `Run testResources.js` file *****");
+function testkoKR(){
+    var rb = new ResBundle({
+        locale:"ko-KR",
+        basePath : defaultRSPath
+    });
+
+    var result1 = rb.getString("TV Name : ").toString();
+    var result2 = rb.getString("Time Settings").toString();
+    var result3 = rb.getString("High", "volumeModeHigh").toString();
+
+    logResults(arguments.callee.name, "TV Name :", result1);
+    logResults(arguments.callee.name, "[App] 시간 설정", result2);
+    logResults(arguments.callee.name, "높음", result3);
+}
+
+function testkoUS(){
+    var rb = new ResBundle({
+        locale:"ko-US",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Antenna NEXTGEN TV").toString();
+    logResults(arguments.callee.name, "안테나 NEXTGEN TV", result1);    
+}
+
+function testenUS(){
+    var rb = new ResBundle({
+        locale:"en-US",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Ivory Coast").toString();
+    var result2 = rb.getString("Programme").toString();
+
+    logResults(arguments.callee.name, "Côte d’Ivoire", result1);
+    logResults(arguments.callee.name, "Channel", result2);
+}
+
+function testenAU(){
+    var rb = new ResBundle({
+        locale:"en-AU",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Service Area Zip Code").toString();
+    var result2 = rb.getString("TV Program Locks").toString();
+    var result3 = rb.getString("Programme").toString();
+    var result4 = rb.getString("Ivory Coast").toString();
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Côte d’Ivoire", result4);
+
+    var existKey = isExistKey("en/AU/strings.json", "Programme");
+    var existKey2 = isExistKey("en/AU/strings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testenGB(){
+    var rb = new ResBundle({
+        locale:"en-GB",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Service Area Zip Code").toString();
+    var result2 = rb.getString("TV Program Locks").toString();
+    var result3 = rb.getString("Programme").toString();
+    var result4 = rb.getString("Ivory Coast").toString();
+
+    logResults(arguments.callee.name, "Service Area Postcode", result1);
+    logResults(arguments.callee.name, "TV Rating Locks", result2);
+    logResults(arguments.callee.name, "Programme", result3);
+    logResults(arguments.callee.name, "Côte d’Ivoire", result4);
+
+    var existKey = isExistKey("en/GB/strings.json", "Programme");
+    var existKey2 = isExistKey("en/GB/strings.json", "Ivory Coast");
+    logResults(arguments.callee.name, true, existKey);
+    logResults(arguments.callee.name, false, existKey2);
+}
+
+function testfrCA(){
+    var rb = new ResBundle({
+        locale:"fr-CA",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Agree").toString();
+    var result2 = rb.getString("Programme").toString();
+
+    logResults(arguments.callee.name, "D’accord", result1);
+    logResults(arguments.callee.name, "Programme", result2);
+}
+
+function testfrFR(){
+    var rb = new ResBundle({
+        locale:"fr-FR",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Agree").toString();
+    var result2 = rb.getString("Others").toString();
+    var existKey = isExistKey("fr/FR/strings.json", "Others");
+
+    logResults(arguments.callee.name, "J'accepte", result1);
+    logResults(arguments.callee.name, "Autres", result2);
+    logResults(arguments.callee.name, false, existKey);
+}
+
+function testesES(){
+    var rb = new ResBundle({
+        locale:"es-ES",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Sound Out").toString();
+    logResults(arguments.callee.name, "Salida de sonido", result1);
+}
+
+function testesCO(){
+    var rb = new ResBundle({
+        locale:"es-CO",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Sound Out").toString();
+    logResults(arguments.callee.name, "Salida de Audio", result1);
+}
+
+function testjaJP(){
+    var rb = new ResBundle({
+        locale:"ja-JP",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("Live TV").toString();
+    var result2 = rb.getString("TV Name : ").toString();
+    logResults(arguments.callee.name, "Live TV", result1);
+    logResults(arguments.callee.name, "機器名：", result2);
+}
+
+function testdeDE(){
+    var rb = new ResBundle({
+        locale:"de-DE",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("EXIT APP").toString();
+    var result2 = rb.getString("SETTINGS").toString();
+
+    logResults(arguments.callee.name, "APP BEENDEN", result1);
+    logResults(arguments.callee.name, "EINSTELLUNGEN", result2);
+}
+
+function testasIN(){
+    var rb = new ResBundle({
+        locale:"as-IN",
+        basePath : defaultRSPath
+    });
+    var result1 = rb.getString("RETRY").toString();
+    var result2 = rb.getString("Restart").toString();
+
+    logResults(arguments.callee.name, "পুনৰ চেষ্টা", result1);
+    logResults(arguments.callee.name, "পুনৰাম্ভ কৰক", result2);
+}
+
+
+
+testkoKR();
+testkoUS();
+testenUS();
+testenAU();
+testenGB();
+testfrCA();
+testfrFR();
+testesCO();
+testesES();
+testjaJP();
+testdeDE();
+testasIN();

--- a/packages/samples-loctool/webos-js/xliffs/as-IN.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/as-IN.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>পুনৰ চেষ্টা</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Restart</source>
+          <target>পুনৰাম্ভ কৰক</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/de-DE.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/de-DE.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>EXIT APP</source>
+          <target>APP BEENDEN</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Hello</source>
+          <target>Hallo</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>RETRY</source>
+          <target>WIEDERHOLEN</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Bye</source>
+          <target>Auf wiedersehen</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>SETTINGS</source>
+          <target>EINSTELLUNGEN</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/en-GB.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="5">
+         <segment>
+            <source>Go to  'Settings > General > Channels > Channel Tuning &amp; Settings > Transponder Edit' and add one.</source>
+            <target>Go to 'Settings > General > Programmes > Programme Tuning &amp; Settings > Transponder Edit' and add one.</target>
+          </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/en-US.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Channel</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>TV Name : </source>
+          <target>TV Name : </target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/fr-CA.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>D’accord</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/fr-FR.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>J'accepte</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ja-JP.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>Live TV</target> <!-- NBSP 00a0 -->
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Space NBSP</source> <!-- source code doesn't have nbsp -->
+          <target>現実の時間とは異なり、</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>To read the Terms and Conditions, go to Settings > Support >  Privacy &amp; Terms.</source>
+          <target>利用規約を読むには、設定 > サポート > 利用規約 &amp; 法的情報に移動します。</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>MAC Address</source>
+          <target>MAC Address </target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>TV Name : </source>
+          <target>機器名：</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 나가기</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Hello</source>
+          <target>안녕</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Thank you</source>
+          <target>고마워</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Bye</source>
+          <target>잘가</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>SETTINGS</source>
+          <target>설정</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>TV Name : </source>
+          <target>TV Name :</target>
+        </segment>
+      </unit>
+      <unit id="8">
+        <segment>
+          <source>Time Settings</source>
+          <target>[App] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="9">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+      <unit id="10" name="volumeModeHigh">
+        <segment>
+          <source>High</source>
+          <target>높음</target>
+        </segment>
+      </unit>
+      <unit id="11">
+        <segment>
+          <source>High</source>
+          <target>최고</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js/xliffs/ko-US.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Antenna NEXTGEN TV</source>
+          <target>안테나 NEXTGEN TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/appinfo.json
+++ b/packages/samples-loctool/webos-json/appinfo.json
@@ -1,0 +1,19 @@
+{
+    "id": "com.app.livetv",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Live TV",
+    "icon": "icon.png",
+    "uiRevision": 2,
+    "transparent": true,
+    "visible": false,
+    "lockable": false,
+    "trustLevel": "trusted",
+    "accessibility": {
+        "supportsAudioGuidance": true
+    },
+    "voiceControl": "manual",
+    "v8SnapshotFile": "snapshot_blob.bin",
+    "vendor": "test"
+}

--- a/packages/samples-loctool/webos-json/common/it-IT.xliff
+++ b/packages/samples-loctool/webos-json/common/it-IT.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Live TV</source>
+          <target>[common]Canali TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Live TV</source>
+          <target>[common]현재 방송</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-qcardinfo",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
-        "loctool": "^2.23.1"
+        "loctool": "^2.28.1"
     },
     "devDependencies": {
         "npm-run-all": "^4.1.5"

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -9,9 +9,9 @@
         "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
-        "sample-test": "node test/testResources.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "sampleAppTest": "pnpm test:all",
+        "run-test": "node test/testResources.js",
+        "execute-all": "npm-run-all clean loc run-test",
+        "testSampleApp": "pnpm execute-all",
         "cleanOutput": "rm -rf *.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -1,0 +1,24 @@
+{
+    "private": true,
+    "name": "sample-webos-qcardinfo",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "clean": "rm -rf *.xliff resources",
+        "sample-test": "node test/testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf *.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-json": "workspace:*",
+        "loctool": "^2.23.1"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-json/project.json
+++ b/packages/samples-loctool/webos-json/project.json
@@ -1,0 +1,55 @@
+{
+    "name": "sample-webos-json",
+    "id": "sample-webos-json",
+    "projectType": "webos-json",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified"
+    },
+    "resourceDirs": {
+        "json": "resources"
+    },
+    "plugins": [
+        "ilib-loctool-webos-json"
+    ],
+    "excludes": [
+        ".*",
+        "xliffs",
+        "resources",
+        "common",
+        "subDirCase"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "en-AU",
+            "en-GB",
+            "en-US",
+            "es-CO",
+            "es-ES",
+            "fr-CA",
+            "fr-FR",
+            "it-IT",
+            "ko-KR",
+            "zh-Hans-CN",
+            "zh-Hant-HK",
+            "zh-Hant-TW"
+        ],
+        "webos": {
+            "commonXliff": "./common"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                },
+                "**/qcardinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        }
+    }
+}

--- a/packages/samples-loctool/webos-json/qcardinfo.json
+++ b/packages/samples-loctool/webos-json/qcardinfo.json
@@ -1,0 +1,7 @@
+{
+    "id": "com.webos.app.sportsteamsettings",
+    "title": "Sports",
+    "description": "All sports information in one place",
+    "image": "$qcardImage.png",
+    "icon": "$qcard_icon.png"
+}

--- a/packages/samples-loctool/webos-json/qcardinfo.schema.json
+++ b/packages/samples-loctool/webos-json/qcardinfo.schema.json
@@ -1,0 +1,16 @@
+{
+    "id": "QCardDescription",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": "The title of the application as it shows in the Launcher and the app window. The application title is unique, set once.",
+            "localizable": true
+        },
+        "description": {
+            "type": "string",
+            "description": "The description of the application as it shows in the Launcher and the app window. The application title is unique, set once.",
+            "localizable": true
+        }
+    }
+}

--- a/packages/samples-loctool/webos-json/subDirCase/app1/appinfo.json
+++ b/packages/samples-loctool/webos-json/subDirCase/app1/appinfo.json
@@ -1,0 +1,4 @@
+{
+    "vendor": "Electronics",
+    "title": "Live TV"
+}

--- a/packages/samples-loctool/webos-json/subDirCase/app1/testResources.js
+++ b/packages/samples-loctool/webos-json/subDirCase/app1/testResources.js
@@ -1,0 +1,74 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+console.log("\n***** `Run app1/testResources.js` file *****");
+
+function test_koKR(){
+    var loadData = loadJSON("ko/appinfo.json");
+    var result1 = loadData["title"];
+    var result2 = loadData["vendor"];
+    logResults(arguments.callee.name, "[common]현재 방송", result1);
+    logResults(arguments.callee.name, "전자", result2);
+}
+
+function test_enUS(){
+    var loadData = loadJSON("appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(en-US) Live TV", result1);
+}
+
+function test_enGB(){
+    var loadData = loadJSON("en/GB/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(en-GB) Live TV", result1);
+}
+
+function test_zhHansCN(){
+    var loadData = loadJSON("zh/appinfo.json");
+    var result1 = loadData["vendor"];   
+    logResults(arguments.callee.name, "电子", result1);
+}
+
+test_koKR();
+test_enUS();
+test_enGB();
+test_zhHansCN();

--- a/packages/samples-loctool/webos-json/subDirCase/app2/appinfo.json
+++ b/packages/samples-loctool/webos-json/subDirCase/app2/appinfo.json
@@ -1,0 +1,4 @@
+{
+    "title": "YouTube Kids",
+    "vendor": "Electronics, Inc."
+}

--- a/packages/samples-loctool/webos-json/subDirCase/app2/testResources.js
+++ b/packages/samples-loctool/webos-json/subDirCase/app2/testResources.js
@@ -1,0 +1,61 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+console.log("\n***** `Run app2/testResources.js` file *****");
+
+function test_ruRU(){
+    var loadData = loadJSON("ru/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "YouTube Детям", result1);
+}
+
+test_ruRU();

--- a/packages/samples-loctool/webos-json/subDirCase/common/it-IT.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/common/it-IT.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Live TV</source>
+          <target>Canali TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Live TV</source>
+          <target>[common]현재 방송</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/package.json
+++ b/packages/samples-loctool/webos-json/subDirCase/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-json-subdir",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {
@@ -16,8 +16,8 @@
     },
     "dependencies": {
         "ilib-loctool-webos-json":  "workspace:*",
-        "loctool": "^2.23.1",
-        "micromatch": "^4.0.5"
+        "loctool": "^2.28.1",
+        "micromatch": "^4.0.8"
     },
     "devDependencies": {
         "npm-run-all": "^4.1.5"

--- a/packages/samples-loctool/webos-json/subDirCase/package.json
+++ b/packages/samples-loctool/webos-json/subDirCase/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "sample-webos-json-subdir",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "clean": "rm -rf *.xliff resources app1/resources app2/resources",
+        "sample-test": "cd app1;node testResources.js;cd ../app2;node testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf *.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-json":  "workspace:*",
+        "loctool": "^2.23.1",
+        "micromatch": "^4.0.5"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-json/subDirCase/package.json
+++ b/packages/samples-loctool/webos-json/subDirCase/package.json
@@ -1,4 +1,5 @@
 {
+    "private": true,
     "name": "sample-webos-json-subdir",
     "description": "Sample localization project",
     "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",

--- a/packages/samples-loctool/webos-json/subDirCase/project.json
+++ b/packages/samples-loctool/webos-json/subDirCase/project.json
@@ -1,0 +1,44 @@
+{
+    "name": "sample-webos-json-subdir",
+    "id": "sample-webos-json-subdir",
+    "projectType": "custom",
+    "sourceLocale": "en-KR",
+    "pseudoLocale": {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified"
+    },
+    "resourceDirs": {
+        "json": "resources"
+    },
+    "plugins": [
+        "ilib-loctool-webos-json"
+    ],
+    "excludes": [
+        ".*",
+        "xliffs",
+        "resources",
+        "common"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "en-GB",
+            "en-US",
+            "ko-KR",
+            "ru-RU",
+            "zh-Hans-CN"
+        ],
+        "webos": {
+            "commonXliff": "./common"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        }
+    }
+}

--- a/packages/samples-loctool/webos-json/subDirCase/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/xliffs/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json-subdir_f1" original="sample-webos-json-subdir">
+    <group id="sample-webos-json-subdir_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-GB) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/xliffs/en-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json-subdir_f1" original="sample-webos-json-subdir">
+    <group id="sample-webos-json-subdir_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-US) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/xliffs/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json-subdir_f1" original="sample-webos-json-subdir">
+    <group id="sample-webos-json-subdir_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Electronics</source>
+          <target>전자</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/xliffs/ru-RU.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/xliffs/ru-RU.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json-subdir_f1" original="sample-webos-json-subdir">
+    <group id="sample-webos-json-subdir_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>YouTube Kids</source>
+          <target>YouTube Детям</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/subDirCase/xliffs/zh-Hans-CN.xliff
+++ b/packages/samples-loctool/webos-json/subDirCase/xliffs/zh-Hans-CN.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json-subdir_f1" original="sample-webos-json-subdir">
+    <group id="sample-webos-json-subdir_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Electronics</source>
+          <target>电子</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/test/testResources.js
+++ b/packages/samples-loctool/webos-json/test/testResources.js
@@ -1,0 +1,170 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadJSON(filepath){
+    var loaddata = {};
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        loaddata = JSON.parse(data);
+        return loaddata;
+    }
+    return loaddata;
+}
+
+function isExistKey(filepath, key){
+    var data, jsonData;
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)) {
+        data = fs.readFileSync(fullPath, "utf-8");
+        jsonData = JSON.parse(data);
+        return (jsonData && jsonData.hasOwnProperty(key)) ? true : false;
+    }
+    return false;
+}
+
+function test_koKR(){
+    var loadData = loadJSON("ko/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "현재 방송", result1);
+}
+
+function test_enUS(){
+    var loadData = loadJSON("appinfo.json");
+    var result1 = loadData["title"];
+    var result2 = loadData["vendor"];
+
+    logResults(arguments.callee.name, "(en-US) Live TV", result1);
+    logResults(arguments.callee.name, "(dup) test", result2);
+}
+
+function test_enAU(){
+    var loadData = loadJSON("en/AU/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(en-GB) Live TV", result1);
+}
+
+function test_enGB(){
+    var loadData = loadJSON("en/GB/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(en-GB) Live TV", result1);
+}
+
+function test_frCA(){
+    var loadData = loadJSON("fr/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(fr) Live TV", result1);
+}
+
+function test_frFR(){
+    var loadData = loadJSON("fr/appinfo.json");
+    var result1 = loadData["title"];
+    logResults(arguments.callee.name, "(fr) Live TV", result1);
+}
+
+function test_esES(){
+    var loadData = loadJSON("es/ES/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "(es-ES) Live TV", result1);
+}
+
+function test_esCO(){
+    var loadData = loadJSON("es/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "(es-CO) Live TV", result1);
+}
+
+function test_itIT(){
+    var loadData = loadJSON("it/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "[common]Canali TV", result1);
+}
+
+function test_zhHansCN(){
+    var loadData = loadJSON("zh/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "直播电视", result1);
+}
+
+function test_zhHantHK(){
+    var loadData = loadJSON("zh/Hant/HK/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "Live TV", result1);
+}
+
+function test_zhHantTW(){
+    var loadData = loadJSON("zh/Hant/TW/appinfo.json");
+    var result1 = loadData["title"];   
+    logResults(arguments.callee.name, "直播電視", result1);
+}
+
+function test_koKR_qcardinfo(){
+    var loadData = loadJSON("ko/qcardinfo.json");
+    var result1 = loadData["title"];
+    var result2 = loadData["description"];
+    logResults(arguments.callee.name, "스포츠", result1);
+    logResults(arguments.callee.name, "스포츠 정보를 한눈에", result2);
+}
+
+function test_frFR_qcardinfo(){
+    var loadData = loadJSON("fr/qcardinfo.json");
+    var result1 = loadData["title"];
+    var result2 = loadData["description"];
+    logResults(arguments.callee.name, "Sports", result1);
+    logResults(arguments.callee.name, "Toutes les informations sportives rassemblées au même endroit", result2);
+}
+
+function test_frCA_qcardinfo(){
+    var loadData = loadJSON("fr/CA/qcardinfo.json");
+    var result = loadData["description"];
+    logResults(arguments.callee.name, "Tous les renseignements sportifs en un seul endroit", result);
+
+    var existKey = isExistKey("fr/CA/qcardinfo.json", "title");
+    logResults(arguments.callee.name, false, existKey);
+}
+
+console.log("\n***** `Run testResources.js` file (appinfo.json) *****");
+test_koKR();
+test_enUS();
+test_enAU();
+test_enGB();
+test_frCA();
+test_frFR();
+test_esES();
+test_esCO();
+test_itIT();
+test_zhHansCN();
+test_zhHantHK();
+test_zhHantTW();
+
+console.log("\n***** `Run testResources.js` file (qcardinfo.json) *****");
+test_koKR_qcardinfo();
+test_frFR_qcardinfo();
+test_frCA_qcardinfo();

--- a/packages/samples-loctool/webos-json/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-GB) Live TV</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>test</source>
+          <target>(dup) test</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/en-US.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(en-US) Live TV</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>test</source>
+          <target>(dup) test</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(es-CO) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(es-ES) Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/fr-CA.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(fr) Live TV</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Sports</source>
+          <target>Sports</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>All sports information in one place</source>
+          <target>Tous les renseignements sportifs en un seul endroit</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/fr-FR.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>(fr) Live TV</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Sports</source>
+          <target>Sports</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>All sports information in one place</source>
+          <target>Toutes les informations sportives rassemblées au même endroit</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/ko-KR.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Sports</source>
+          <target>스포츠</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>All sports information in one place</source>
+          <target>스포츠 정보를 한눈에</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hans-CN.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hans-CN.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>直播电视</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hant-HK.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hant-HK.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-HK" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hant-TW.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hant-TW.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-TW" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-json_f1" original="sample-webos-json">
+    <group id="sample-webos-json_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>直播電視</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/appinfo.json
+++ b/packages/samples-loctool/webos-qml/appinfo.json
@@ -1,0 +1,9 @@
+{
+    "id": "musc",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Music",
+    "icon": "icon.png",
+    "vendor": "test"
+}

--- a/packages/samples-loctool/webos-qml/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-qml/common/en-GB.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+      <unit id="common_3">
+        <segment>
+            <source>App Name\n(A to Z)</source>
+            <target>(common) App Name\n(A to Z)</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-qml/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-qml/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-qml/common/fr-CA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-qml/common/fr-FR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/it-IT.xliff
+++ b/packages/samples-loctool/webos-qml/common/it-IT.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] Impostazioni Orario</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] Immettere la password.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-qml/common/ko-KR.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>[common] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Please enter password.</source>
+          <target>[common] 비밀번호를 입력해 주세요.</target>
+        </segment>
+      </unit>
+      <unit id="common_3">
+        <segment>
+          <source>Music</source>
+          <target>음악</target>
+        </segment>
+      </unit>
+      <unit id="common_4">
+        <segment>
+            <source>App Name\n(A to Z)</source>
+            <target>(common) 명칭 순</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/package.json
+++ b/packages/samples-loctool/webos-qml/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "sample-webos-qml",
     "description": "Sample localization project",
-    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
     "scripts": {

--- a/packages/samples-loctool/webos-qml/package.json
+++ b/packages/samples-loctool/webos-qml/package.json
@@ -9,10 +9,10 @@
         "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB,en-JP:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB",
         "clean": "rm -rf *.xliff resources",
-        "sample-test": "node test/testResources.js",
+        "run-test": "node test/testResources.js",
         "test-debug": "node --inspect-brk test/testResources.js",
-        "test:all": "npm-run-all clean loc sample-test",
-        "sampleAppTest": "pnpm test:all",
+        "execute-all": "npm-run-all clean loc run-test",
+        "testSampleApp": "pnpm execute-all",
         "cleanOutput": "rm -rf *.xliff music-*.xliff resources"
     },
     "dependencies": {

--- a/packages/samples-loctool/webos-qml/package.json
+++ b/packages/samples-loctool/webos-qml/package.json
@@ -1,0 +1,28 @@
+{
+    "private": true,
+    "name": "sample-webos-qml",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-loctool-samples.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB,en-JP:en-GB --pseudo",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --pseudo --localeMap es-CO:es --localeInherit en-AU:en-GB",
+        "clean": "rm -rf *.xliff resources",
+        "sample-test": "node test/testResources.js",
+        "test-debug": "node --inspect-brk test/testResources.js",
+        "test:all": "npm-run-all clean loc sample-test",
+        "sampleAppTest": "pnpm test:all",
+        "cleanOutput": "rm -rf *.xliff music-*.xliff resources"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-json": "workspace:*",
+        "ilib-loctool-webos-qml": "workspace:*",
+        "ilib-loctool-webos-ts-resource": "workspace:*",
+        "loctool": "^2.28.1",
+        "xml-js": "^1.6.11"
+    },
+    "devDependencies": {
+        "npm-run-all": "^4.1.5"
+    }
+}

--- a/packages/samples-loctool/webos-qml/project.json
+++ b/packages/samples-loctool/webos-qml/project.json
@@ -1,0 +1,60 @@
+{
+    "name": "music",
+    "id": "music",
+    "projectType": "webos-qml",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified",
+        "as-XX" : "debug-font"
+    },
+    "resourceDirs": {
+        "ts": "resources",
+        "json": "resources"
+    },
+    "resourceFileTypes": {
+        "ts": "ilib-loctool-webos-ts-resource",
+        "json": "ilib-loctool-webos-json"
+    },
+    "plugins": [
+        "ilib-loctool-webos-qml"
+    ],
+    "excludes": [
+        ".*",
+        "resources"
+    ],
+    "settings": {
+        "xliffsDir": "./xliffs",
+        "locales":[
+            "as-IN",
+            "en-AU",
+            "en-US",
+            "en-GB",
+            "en-JP",
+            "es-CO",
+            "es-ES",
+            "fr-CA",
+            "fr-FR",
+            "it-IT",
+            "ko-KR"
+        ],
+        "localeMap": {
+            "fr-CA": "fr"
+        },
+        "webos": {
+            "commonXliff": "./common"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        },
+        "qml": {
+            "disablePseudo" : true
+        }
+    }
+}

--- a/packages/samples-loctool/webos-qml/src/StringSheet.qml
+++ b/packages/samples-loctool/webos-qml/src/StringSheet.qml
@@ -1,0 +1,50 @@
+﻿import QtQuick 2.4
+import QmlAppComponents 0.1
+
+AppStringSheet {
+    id: root
+    appTitle: rtlCode + qsTr("Music") + es
+    appId: "music"
+    property QtObject common: QtObject {
+        property string noImage: qsTr("No Image") + es
+    }
+    property QtObject titleView: QtObject {
+        property string musicPlayerTitle: qsTr("Audio") + es
+        property string musicListTitle: qsTr("Now Playing") + es
+        property string musicListTitle: qsTr("Sound Out") + es
+    }
+    property QtObject categoryView: QtObject {
+        property var devices: [
+            qsTr("USB") + es,
+            qsTr("Radio") + es
+        ]
+        property var sorts: [
+            qsTr("Playlist") + es,
+            qsTr("Albums") + es,
+            qsTr("Artists") + es,
+            qsTr("Songs") + es,
+            qsTr("Genres") + es
+            qsTr("TV Program Locks") + es,
+            qsTr("Service Area Zip Code") + es,
+            qsTr("Time Settings") + es,
+            qsTr("Please enter password.") + es,
+            qsTr("Game Optimizer") + es,
+            qsTr("HDMI Deep Color") + es,
+            qsTr("Exit") + es,
+            qsTr("Others") + es,
+            qsTr("Don\'t save") + es
+            qsTr("RETRY") + es
+            qsTr("Restart") + es
+            qsTr("Standard", "Menu.Standard") + es
+        ]
+    }
+    Text {
+        id: checkNetworkDescription
+        text: qsTr("Network is not connected.\nPlease check the Network Settings and try again.") + Settings.l10n.tr
+    }
+    Text {
+        id: loadingDescription
+        text: qsTr("Loading.\nPlease wait.") + Settings.l10n.tr
+        text: qsTr("App Name\n(A to Z)") + Settings.l10n.tr
+    }
+}

--- a/packages/samples-loctool/webos-qml/src/appLaunch.js
+++ b/packages/samples-loctool/webos-qml/src/appLaunch.js
@@ -1,0 +1,1 @@
+qsTranslate("appLaunch", "This function is not supported.")

--- a/packages/samples-loctool/webos-qml/src/sample.js
+++ b/packages/samples-loctool/webos-qml/src/sample.js
@@ -1,0 +1,4 @@
+var strings = {
+    "string1": qsTr("Settings"),
+    "string2": qsTranslate("context", "Search"),
+}

--- a/packages/samples-loctool/webos-qml/src/systemUI.js
+++ b/packages/samples-loctool/webos-qml/src/systemUI.js
@@ -1,0 +1,1 @@
+qsTranslate("appLaunch", "This function is not supported.")

--- a/packages/samples-loctool/webos-qml/test/testResources.js
+++ b/packages/samples-loctool/webos-qml/test/testResources.js
@@ -1,0 +1,234 @@
+/*
+ * testResources.js - test file to verify generated resources.
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var fs = require("fs");
+var path = require("path");
+var xmljs = require("xml-js");
+var defaultRSPath = path.join(process.cwd(), "resources");
+
+function logResults(testname, expected, actual) {
+    if (expected === actual) {
+        console.log(testname + " has passed.");
+    } else {
+        console.log(testname + " has failed." +  "\n\texpected:\t"+expected+"\tactual:\t\t"+actual);
+    }
+}
+
+function loadResource(filepath){
+    var fullPath = path.join(defaultRSPath, filepath);
+    if (fs.existsSync(fullPath)){
+        var tsFile = fs.readFileSync(fullPath, "utf8");
+        var options = {trim:false, nativeTypeAttribute: true, compact: true};
+        var result = xmljs.xml2js(tsFile, options);
+        loaddata = result.TS;
+    }
+    return loaddata;
+}
+
+function compareOutput(funcName, contextRes, expected) {
+    for(var i=0; i < contextRes.length; i++) {
+        var name = contextRes[i].name._text;
+        var msg = contextRes[i].message;
+        var translation;
+        msg = Array.isArray(msg) === true ? msg : [msg];
+
+        for(var j=0; j < msg.length; j++) {
+            translation = msg[j].translation._text;
+            logResults(funcName, expected[name][j], translation);
+        }
+    }
+}
+
+function line() {
+    console.log("---------------------------------");
+}
+
+console.log("\n***** `Run testResources.js` file *****");
+
+function testkoKR(){
+    var loadData = loadResource("music_ko.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 4);
+
+    var expected = {
+        "StringSheet": [ "앨범", "(common) 명칭 순", "오디오", "저장 안 함", "장르",
+                        "컨텐츠 로딩 중입니다.\n잠시만 기다려 주세요.",
+                        "기 본", "음악", '네트워크가 연결되지 않았습니다.\n네트워크 설정 확인 후 다시 시도하세요.',
+                        "재생 중", "재생목록",'[common] 비밀번호를 입력해 주세요.', "노래", "[common] 시간 설정"],
+        "context" : ["검색"],
+        "sample" : ["설정"],
+        "systemUI": ['사용할 수 없는 기능입니다.'],
+        "appLaunch": ['사용할 수 없는 기능입니다.']
+    }
+    compareOutput("testkoKR", contextRes, expected);
+    line();
+}
+
+function testenUS(){
+    var loadData = loadResource("music_en.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Service Area Zip Code", "TV Program Locks"]
+    }
+    compareOutput("testenUS", contextRes, expected);
+    line();
+}
+
+function testenJP(){
+    var loadData = loadResource("music_en_JP.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["(common) App Name\n(A to Z)", "Game Optimiser", "HDMI Deep Colour", "(enGB) Loading.\nPlease wait.", "Service Area Postcode", "TV Rating Locks"]
+    }
+    compareOutput("testenJP", contextRes, expected);
+    line();
+}
+
+function testenGB(){
+    var loadData = loadResource("music_en_GB.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["(common) App Name\n(A to Z)", "Game Optimiser", "HDMI Deep Colour", "(enGB) Loading.\nPlease wait.", "Service Area Postcode", "TV Rating Locks"]
+    }
+    compareOutput("testenGB", contextRes, expected);
+    line();
+}
+function testenAU(){
+    var loadData = loadResource("music_en_AU.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["(common) App Name\n(A to Z)", "Game Optimiser", "HDMI Deep Colour", "(enGB) Loading.\nPlease wait.", "Service Area Postcode", "TV Rating Locks"]
+    }
+    compareOutput("testenAU", contextRes, expected);
+    line();
+}
+
+function testesES(){
+    var loadData = loadResource("music_es_ES.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Salida de sonido"]
+    }
+    compareOutput("testesES", contextRes, expected);
+    line();
+}
+
+function testesCO(){
+    var loadData = loadResource("music_es.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Salida de Audio"]
+    }
+    compareOutput("testesCO", contextRes, expected);
+    line();
+}
+
+function testfrFR(){
+    var loadData = loadResource("music_fr_FR.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Quitter", "Autres"]
+    }
+    compareOutput("testfrFR", contextRes, expected);
+    line();
+}
+
+function testfrCA(){
+    var loadData = loadResource("music_fr.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Quitter"]
+    }
+    compareOutput("testfrCA", contextRes, expected);
+    line();
+}
+
+function testitIT(){
+    var loadData = loadResource("music_it.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["Album", "Audio", "Generi", "Musica", "Ora in riproduzione", "Elenco di riproduzione",
+        "[common] Immettere la password.", "Canzoni", "[common] Impostazioni Orario"]
+    }
+    compareOutput("testitIT", contextRes, expected);
+    line();
+}
+
+function testasIN(){
+    var loadData = loadResource("music_as.ts");
+    
+    var contextRes = loadData.context;
+    contextRes = Array.isArray(contextRes) === true ? contextRes : [contextRes];
+    logResults(arguments.callee.name, contextRes.length, 1);
+
+    var expected = {
+        "StringSheet": ["পুনৰ চেষ্টা", "পুনৰাম্ভ কৰক"]
+    }
+    compareOutput("testasIN", contextRes, expected);
+    line();
+}
+
+testkoKR();
+testenUS();
+testenJP();
+testenGB();
+testenAU();
+testesES();
+testesCO();
+testfrFR();
+testfrCA();
+testitIT();
+testasIN();

--- a/packages/samples-loctool/webos-qml/xliffs/as-IN.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/as-IN.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>পুনৰ চেষ্টা</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Restart</source>
+          <target>পুনৰাম্ভ কৰক</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/en-GB.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+            <source>Loading.\nPlease wait.</source>
+            <target>(enGB) Loading.\nPlease wait.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/en-US.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/it-IT.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/it-IT.xliff
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>Music</source>
+          <target>Musica</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Audio</source>
+          <target>Audio</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Now Playing</source>
+          <target>Ora in riproduzione</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Playlist</source>
+          <target>Elenco di riproduzione</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Albums</source>
+          <target>Album</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>Songs</source>
+          <target>Canzoni</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>Genres</source>
+          <target>Generi</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-qml/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/ko-KR.xliff
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="music_f1" original="music">
+    <group id="music_g1" name="x-qml">
+      <unit id="1">
+        <segment>
+          <source>Music</source>
+          <target>음악</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Audio</source>
+          <target>오디오</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Now Playing</source>
+          <target>재생 중</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Playlist</source>
+          <target>재생목록</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Albums</source>
+          <target>앨범</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>Songs</source>
+          <target>노래</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>Genres</source>
+          <target>장르</target>
+        </segment>
+      </unit>
+      <unit id="8">
+        <segment>
+          <source>Settings</source>
+          <target>설정</target>
+        </segment>
+      </unit>
+      <unit id="9">
+        <segment>
+          <source>Search</source>
+          <target>검색</target>
+        </segment>
+      </unit>
+      <unit id="10">
+        <segment>
+            <source>Don't save</source>
+            <target>저장 안 함</target>
+        </segment>
+      </unit>
+       <unit id="11">
+    <segment>
+     <source>Network is not connected.
+Please check the Network Settings and try again.</source>
+     <target>네트워크가 연결되지 않았습니다.
+네트워크 설정 확인 후 다시 시도하세요.</target>
+    </segment>
+   </unit>
+   <unit id="12">
+        <segment>
+            <source>This function is not supported.</source>
+            <target>사용할 수 없는 기능입니다.</target>
+        </segment>
+      </unit>
+      <unit id="13" name="Menu.Standard">
+        <segment>
+            <source>Standard</source>
+            <target>기 본</target>
+        </segment>
+      </unit>
+      <unit id="14">
+        <segment>
+            <source>Standard</source>
+            <target>기 준</target>
+        </segment>
+      </unit>
+      <unit id="15">
+        <segment>
+            <source>Loading.\nPlease wait.</source>
+            <target>컨텐츠 로딩 중입니다.\n잠시만 기다려 주세요.</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,15 +189,6 @@ importers:
         specifier: 2.28.1
         version: 2.28.1
 
-  packages/samples-lint:
-    dependencies:
-      ilib-lint:
-        specifier: ^2.7.2
-        version: 2.7.2
-      ilib-lint-webos:
-        specifier: workspace:*
-        version: link:../ilib-lint-webos
-
   packages/samples-loctool/webos-c:
     dependencies:
       ilib-loctool-webos-c:
@@ -845,10 +836,6 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
-  array.prototype.map@1.0.8:
-    resolution: {integrity: sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==}
-    engines: {node: '>= 0.4'}
-
   array.prototype.reduce@1.0.7:
     resolution: {integrity: sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==}
     engines: {node: '>= 0.4'}
@@ -1188,9 +1175,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
-
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -1478,25 +1462,8 @@ packages:
     resolution: {integrity: sha512-WiNVrKpwdPn1sEqGYXs4DXZBqSTrEAzBWKQKVuoGz+Uh7ru0gvBJUtbm3WLlKEN9elQj0AFTBI3XHG/LOKnaqA==}
     engines: {node: '>=14.0.0'}
 
-  ilib-lint@2.7.2:
-    resolution: {integrity: sha512-WTCjLML8+9/0sLZ8WnSK9iovxlBehf6lWhC2eqh5kqY3mIEmWwqKFZAAq6/D7mtBrVYD2GBYokQ3uSiQkXem8Q==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-
-  ilib-loader@1.3.5:
-    resolution: {integrity: sha512-EeEb652VmB6aAO5nvth3bIHyAapgukxn/7Zyf0mCEhGNCLMv3b6IqbXCRZVrztrgzu/fTLdQKQtq4pO+6ImOCg==}
-
   ilib-locale@1.2.4:
     resolution: {integrity: sha512-3ZIOw45MAmL+uQ1CTt7A/eVOd5wEYlmTWPnQC/GFmGaIxbGvgSD9AuIX1HiFltYQXIBlQWl0yTFf/1yPtfW3ng==}
-
-  ilib-localedata@1.5.2:
-    resolution: {integrity: sha512-qDAOOKFYYguLPT+kj2sVCk97tgPAZztQbmvtUdhHGkWEZX7nm7G97MumaDToATy3N8iccfEO8l0KVxVOTxAEcA==}
-
-  ilib-localeinfo@1.1.0:
-    resolution: {integrity: sha512-F77DV01lWANKqEw1QxEqYNO3Jj3H30kkYMGinMWoCIF18Kb/Gc/aJaaENWlS9kfZkbvfXthcBL7kuswMY+Hjdg==}
-
-  ilib-localematcher@1.3.1:
-    resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
 
   ilib-po@1.1.0:
     resolution: {integrity: sha512-XeIBBbo4YH9I6ltc/d5x9j3CyUHVVmDA632ESKk816fWoHWRcY9p8JhKMrYk3HWW/pLgJVWSa5O9bPJu2nw6GQ==}
@@ -1556,10 +1523,6 @@ packages:
 
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
-
-  is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1746,12 +1709,6 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
-
-  iterate-iterator@1.0.2:
-    resolution: {integrity: sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==}
-
-  iterate-value@1.0.2:
-    resolution: {integrity: sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -2152,9 +2109,6 @@ packages:
   opencc-js@1.0.5:
     resolution: {integrity: sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg==}
 
-  options-parser@0.4.0:
-    resolution: {integrity: sha512-KZTzRU3jlv9DVWakQGacYJN3GBP6KY6bb5Gh+QWy88ayADNCj5ql8a4604jBnorQ/bsVja4zjy8q0W8v+71gyg==}
-
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -2273,10 +2227,6 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  promise.allsettled@1.0.7:
-    resolution: {integrity: sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==}
-    engines: {node: '>= 0.4'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -2523,10 +2473,6 @@ packages:
 
   state-toggle@1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
-
-  stop-iteration-iterator@1.1.0:
-    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
-    engines: {node: '>= 0.4'}
 
   stream-connect@1.0.2:
     resolution: {integrity: sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==}
@@ -3670,16 +3616,6 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  array.prototype.map@1.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.3
-      define-properties: 1.2.1
-      es-abstract: 1.23.6
-      es-array-method-boxes-properly: 1.0.0
-      es-object-atoms: 1.0.0
-      is-string: 1.1.1
-
   array.prototype.reduce@1.0.7:
     dependencies:
       call-bind: 1.0.8
@@ -4112,18 +4048,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-get-iterator@1.1.3:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.2.6
-      has-symbols: 1.1.0
-      is-arguments: 1.2.0
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
-
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4444,59 +4368,9 @@ snapshots:
 
   ilib-lint-common@3.1.2: {}
 
-  ilib-lint@2.7.2:
-    dependencies:
-      '@formatjs/intl': 2.10.15
-      ilib-common: 1.1.6
-      ilib-lint-common: 3.1.2
-      ilib-locale: 1.2.4
-      ilib-localeinfo: 1.1.0
-      ilib-tools-common: 1.13.0
-      intl-messageformat: 10.7.15
-      json5: 2.2.3
-      log4js: 6.9.1
-      micromatch: 4.0.8
-      options-parser: 0.4.0
-      xml-js: 1.6.11
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  ilib-loader@1.3.5:
-    dependencies:
-      '@log4js-node/log4js-api': 1.0.2
-      ilib-common: 1.1.6
-      ilib-env: 1.4.1
-      promise.allsettled: 1.0.7
-
   ilib-locale@1.2.4:
     dependencies:
       ilib-env: 1.4.1
-
-  ilib-localedata@1.5.2:
-    dependencies:
-      '@log4js-node/log4js-api': 1.0.2
-      ilib-common: 1.1.6
-      ilib-env: 1.4.1
-      ilib-loader: 1.3.5
-      ilib-locale: 1.2.4
-      ilib-localematcher: 1.3.1
-      json5: 2.2.3
-
-  ilib-localeinfo@1.1.0:
-    dependencies:
-      '@log4js-node/log4js-api': 1.0.2
-      ilib-common: 1.1.6
-      ilib-env: 1.4.1
-      ilib-locale: 1.2.4
-      ilib-localedata: 1.5.2
-      ilib-localematcher: 1.3.1
-      json5: 2.2.3
-
-  ilib-localematcher@1.3.1:
-    dependencies:
-      ilib-common: 1.1.6
-      ilib-locale: 1.2.4
 
   ilib-po@1.1.0:
     dependencies:
@@ -4572,11 +4446,6 @@ snapshots:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
-
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.3
-      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4758,13 +4627,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  iterate-iterator@1.0.2: {}
-
-  iterate-value@1.0.2:
-    dependencies:
-      es-get-iterator: 1.1.3
-      iterate-iterator: 1.0.2
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -5415,8 +5277,6 @@ snapshots:
 
   opencc-js@1.0.5: {}
 
-  options-parser@0.4.0: {}
-
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -5509,15 +5369,6 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
-
-  promise.allsettled@1.0.7:
-    dependencies:
-      array.prototype.map: 1.0.8
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.23.6
-      get-intrinsic: 1.2.6
-      iterate-value: 1.0.2
 
   prompts@2.4.2:
     dependencies:
@@ -5797,11 +5648,6 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   state-toggle@1.0.3: {}
-
-  stop-iteration-iterator@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      internal-slot: 1.1.0
 
   stream-connect@1.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,28 @@ importers:
         specifier: 2.28.1
         version: 2.28.1
 
+  packages/samples-loctool/webos-js:
+    dependencies:
+      ilib:
+        specifier: ^14.21.0
+        version: 14.21.0
+      ilib-loctool-webos-javascript:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-javascript
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.1
+        version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,57 @@ importers:
         specifier: 2.28.1
         version: 2.28.1
 
+  packages/samples-loctool/webos-c:
+    dependencies:
+      ilib-loctool-webos-c:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-c
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.1
+        version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/samples-loctool/webos-cpp:
+    dependencies:
+      ilib-loctool-webos-cpp:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-cpp
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.1
+        version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/samples-loctool/webos-dart:
+    dependencies:
+      ilib-loctool-webos-dart:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-dart
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.1
+        version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
   packages/samples-loctool/webos-js:
     dependencies:
       ilib:
@@ -206,6 +257,57 @@ importers:
       loctool:
         specifier: ^2.28.1
         version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/samples-loctool/webos-json:
+    dependencies:
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json
+      loctool:
+        specifier: ^2.23.1
+        version: 2.28.1
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/samples-loctool/webos-json/subDirCase:
+    dependencies:
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../../ilib-loctool-webos-json
+      loctool:
+        specifier: ^2.23.1
+        version: 2.28.1
+      micromatch:
+        specifier: ^4.0.5
+        version: 4.0.8
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  packages/samples-loctool/webos-qml:
+    dependencies:
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json
+      ilib-loctool-webos-qml:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-qml
+      ilib-loctool-webos-ts-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-ts-resource
+      loctool:
+        specifier: ^2.28.1
+        version: 2.28.1
+      xml-js:
+        specifier: ^1.6.11
+        version: 1.6.11
     devDependencies:
       npm-run-all:
         specifier: ^4.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,15 @@ importers:
         specifier: 2.28.1
         version: 2.28.1
 
+  packages/samples-lint:
+    dependencies:
+      ilib-lint:
+        specifier: ^2.7.2
+        version: 2.7.2
+      ilib-lint-webos:
+        specifier: workspace:*
+        version: link:../ilib-lint-webos
+
   packages/samples-loctool/webos-c:
     dependencies:
       ilib-loctool-webos-c:
@@ -268,7 +277,7 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.23.1
+        specifier: ^2.28.1
         version: 2.28.1
     devDependencies:
       npm-run-all:
@@ -281,10 +290,10 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.23.1
+        specifier: ^2.28.1
         version: 2.28.1
       micromatch:
-        specifier: ^4.0.5
+        specifier: ^4.0.8
         version: 4.0.8
     devDependencies:
       npm-run-all:
@@ -836,6 +845,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  array.prototype.map@1.0.8:
+    resolution: {integrity: sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==}
+    engines: {node: '>= 0.4'}
+
   array.prototype.reduce@1.0.7:
     resolution: {integrity: sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==}
     engines: {node: '>= 0.4'}
@@ -1175,6 +1188,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -1462,8 +1478,25 @@ packages:
     resolution: {integrity: sha512-WiNVrKpwdPn1sEqGYXs4DXZBqSTrEAzBWKQKVuoGz+Uh7ru0gvBJUtbm3WLlKEN9elQj0AFTBI3XHG/LOKnaqA==}
     engines: {node: '>=14.0.0'}
 
+  ilib-lint@2.7.2:
+    resolution: {integrity: sha512-WTCjLML8+9/0sLZ8WnSK9iovxlBehf6lWhC2eqh5kqY3mIEmWwqKFZAAq6/D7mtBrVYD2GBYokQ3uSiQkXem8Q==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  ilib-loader@1.3.5:
+    resolution: {integrity: sha512-EeEb652VmB6aAO5nvth3bIHyAapgukxn/7Zyf0mCEhGNCLMv3b6IqbXCRZVrztrgzu/fTLdQKQtq4pO+6ImOCg==}
+
   ilib-locale@1.2.4:
     resolution: {integrity: sha512-3ZIOw45MAmL+uQ1CTt7A/eVOd5wEYlmTWPnQC/GFmGaIxbGvgSD9AuIX1HiFltYQXIBlQWl0yTFf/1yPtfW3ng==}
+
+  ilib-localedata@1.5.2:
+    resolution: {integrity: sha512-qDAOOKFYYguLPT+kj2sVCk97tgPAZztQbmvtUdhHGkWEZX7nm7G97MumaDToATy3N8iccfEO8l0KVxVOTxAEcA==}
+
+  ilib-localeinfo@1.1.0:
+    resolution: {integrity: sha512-F77DV01lWANKqEw1QxEqYNO3Jj3H30kkYMGinMWoCIF18Kb/Gc/aJaaENWlS9kfZkbvfXthcBL7kuswMY+Hjdg==}
+
+  ilib-localematcher@1.3.1:
+    resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
 
   ilib-po@1.1.0:
     resolution: {integrity: sha512-XeIBBbo4YH9I6ltc/d5x9j3CyUHVVmDA632ESKk816fWoHWRcY9p8JhKMrYk3HWW/pLgJVWSa5O9bPJu2nw6GQ==}
@@ -1523,6 +1556,10 @@ packages:
 
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1709,6 +1746,12 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
+
+  iterate-iterator@1.0.2:
+    resolution: {integrity: sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==}
+
+  iterate-value@1.0.2:
+    resolution: {integrity: sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -2109,6 +2152,9 @@ packages:
   opencc-js@1.0.5:
     resolution: {integrity: sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg==}
 
+  options-parser@0.4.0:
+    resolution: {integrity: sha512-KZTzRU3jlv9DVWakQGacYJN3GBP6KY6bb5Gh+QWy88ayADNCj5ql8a4604jBnorQ/bsVja4zjy8q0W8v+71gyg==}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -2227,6 +2273,10 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  promise.allsettled@1.0.7:
+    resolution: {integrity: sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==}
+    engines: {node: '>= 0.4'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -2473,6 +2523,10 @@ packages:
 
   state-toggle@1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
 
   stream-connect@1.0.2:
     resolution: {integrity: sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==}
@@ -3616,6 +3670,16 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  array.prototype.map@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.3
+      define-properties: 1.2.1
+      es-abstract: 1.23.6
+      es-array-method-boxes-properly: 1.0.0
+      es-object-atoms: 1.0.0
+      is-string: 1.1.1
+
   array.prototype.reduce@1.0.7:
     dependencies:
       call-bind: 1.0.8
@@ -4048,6 +4112,18 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.2.6
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
+
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4368,9 +4444,59 @@ snapshots:
 
   ilib-lint-common@3.1.2: {}
 
+  ilib-lint@2.7.2:
+    dependencies:
+      '@formatjs/intl': 2.10.15
+      ilib-common: 1.1.6
+      ilib-lint-common: 3.1.2
+      ilib-locale: 1.2.4
+      ilib-localeinfo: 1.1.0
+      ilib-tools-common: 1.13.0
+      intl-messageformat: 10.7.15
+      json5: 2.2.3
+      log4js: 6.9.1
+      micromatch: 4.0.8
+      options-parser: 0.4.0
+      xml-js: 1.6.11
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  ilib-loader@1.3.5:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      promise.allsettled: 1.0.7
+
   ilib-locale@1.2.4:
     dependencies:
       ilib-env: 1.4.1
+
+  ilib-localedata@1.5.2:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      ilib-loader: 1.3.5
+      ilib-locale: 1.2.4
+      ilib-localematcher: 1.3.1
+      json5: 2.2.3
+
+  ilib-localeinfo@1.1.0:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      ilib-locale: 1.2.4
+      ilib-localedata: 1.5.2
+      ilib-localematcher: 1.3.1
+      json5: 2.2.3
+
+  ilib-localematcher@1.3.1:
+    dependencies:
+      ilib-common: 1.1.6
+      ilib-locale: 1.2.4
 
   ilib-po@1.1.0:
     dependencies:
@@ -4446,6 +4572,11 @@ snapshots:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.3
+      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4627,6 +4758,13 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  iterate-iterator@1.0.2: {}
+
+  iterate-value@1.0.2:
+    dependencies:
+      es-get-iterator: 1.1.3
+      iterate-iterator: 1.0.2
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -5277,6 +5415,8 @@ snapshots:
 
   opencc-js@1.0.5: {}
 
+  options-parser@0.4.0: {}
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -5369,6 +5509,15 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  promise.allsettled@1.0.7:
+    dependencies:
+      array.prototype.map: 1.0.8
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.6
+      get-intrinsic: 1.2.6
+      iterate-value: 1.0.2
 
   prompts@2.4.2:
     dependencies:
@@ -5648,6 +5797,11 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   state-toggle@1.0.3: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   stream-connect@1.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-  - "packages/*"
+  - "packages/**"

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,9 @@
       },
       "test": {
         "dependsOn": ["build", "^test"]
+      },
+      "sampleAppTest": {
+        "dependsOn": []
       }
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,9 @@
       },
       "sampleAppTest": {
         "dependsOn": []
+      },
+      "cleanOutput": {
+        "dependsOn": []
       }
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "test": {
         "dependsOn": ["build", "^test"]
       },
-      "sampleAppTest": {
+      "testSampleApp": {
         "dependsOn": []
       },
       "cleanOutput": {


### PR DESCRIPTION
### Description
Migrate loctool and sample apps from the ilib-loctool-samples repository.
One app type typically uses two plugins. Therefore, Not only for the unit tests for each plugin, but a sample that verifies the overall functionality is needed, and these samples are written for each app type. : ``` webos-js, webos-c, webos-cpp, webos-qml, webos-dart, webos-json```

To prevent npm publish, I added ```private: true``` to the package.json of sample app
Each app has test cases written as simple Node programs to validate values. These are not written in Jest. Additional configurations have been added to run them. --> ```pnpm testSampleApp```

### Misc
Fixed the configuration that was preventing the Jest debugger from working

### Notes
In the future, it will be necessary to convert these test cases to Jest to improve coverage results.
The lint sample migration will work in a different PR. because there is an issue when upgrading ilib-lint to the latest version. I plan to move it separately after resolving these issues.
