### PR TITLE
Migrate the lint-webos sample from the ilib-samples repository

### DIFF
--- a/.github/workflows/test-affected.yml
+++ b/.github/workflows/test-affected.yml
@@ -37,7 +37,7 @@ jobs:
                   # per https://github.com/vercel/turborepo/issues/9320#issuecomment-2499219314
                   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
             - name: Affected packages test and coverage
-              run: pnpm coverage:ci:affected
+              run: pnpm coverage
               env:
                   # temporary workaround for `Failed to resolve base ref 'main' from GitHub Actions event`:
                   # manually set PR base commit ref

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Plugins are optimized for the webOS platform.
 * ilib-lint-webos: provides the ability to parse webOS xliff files and provides rules to check.
 * ilib-loctool-webos-dist: for the purpose of distribution for webOS platform.
 * samples-loctool: sample apps written for each app type to validate the webOS loctool plugins.
+* samples-lint: sample app to validate the webOS lint plugin.
 
 ## License
 This project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE) file for details.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 coverage:
   ignore:
     - "packages/samples-lint"
-    - "packages/samples-loctool"
     - "packages/ilib-loctool-webos-dist"
     - "scripts"
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   ignore:
     - "packages/samples-lint"
+    - "packages/samples-loctool"
     - "packages/ilib-loctool-webos-dist"
     - "scripts"
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,7 @@ coverage:
         threshold: 0%
         # advanced settings
         informational: false
-        only_pulls: true
+        only_pulls: false
 comment:                  #this is a top-level key
   layout: " diff, flags, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,5 +17,5 @@ comment:                  #this is a top-level key
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
-  require_head: true       # [true :: must have a head report to post]
+  require_head: false       # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,11 +12,11 @@ coverage:
         threshold: 0%
         # advanced settings
         informational: false
-        only_pulls: false
+        only_pulls: true
 comment:                  #this is a top-level key
   layout: " diff, flags, files"
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: false        # [true :: must have a base report to post]
-  require_head: false       # [true :: must have a head report to post]
+  require_head: true       # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 coverage:
+  ignore:
+    - "packages/samples-lint"
+    - "packages/samples-loctool"
+    - "packages/ilib-loctool-webos-dist"
+    - "scripts"
   status:
     project:
       default:

--- a/packages/samples-lint/ilib-lint-config.json
+++ b/packages/samples-lint/ilib-lint-config.json
@@ -1,0 +1,35 @@
+ {
+    "name": "webOS-lint",
+    "sourceLocale": "en-KR",
+    "locales": [],
+    "plugins": [
+        "ilib-lint-webos"
+    ],
+    "rulesets": {
+        "webos-translation-rules": {
+            "resource-url-match": true,
+            "resource-named-params": true,
+            "resource-quote-style": true,
+            "resource-unique-keys": true,
+            "resource-edge-whitespace": true,
+            "resource-completeness": true,
+            "resource-no-fullwidth-latin": true,
+            "resource-no-fullwidth-digits": true,
+            "resource-no-fullwidth-punctuation-subset": true,
+            "resource-no-space-between-double-and-single-byte-character": true,
+            "resource-no-halfwidth-kana-characters": true,
+            "resource-no-double-byte-space": true,
+            "resource-no-space-with-fullwidth-punctuation": true
+        }
+    },
+    "filetypes":{
+        "xliff" : {
+            "ruleset": [ 
+                "webos-translation-rules"
+            ]
+        }
+    },
+    "paths": {
+        "**/[a-z][a-z]*-([A-Z][A-Z]).xliff": "xliff"
+    }
+}

--- a/packages/samples-lint/ilib-lint-config.template.json
+++ b/packages/samples-lint/ilib-lint-config.template.json
@@ -1,0 +1,58 @@
+{
+    "name": "settings-lint",
+    "sourceLocale": "en-KR",
+    "locales": [
+        "en-US",
+        "de-DE",
+        "ja-JP",
+        "ko-KR",
+        "am-ET"
+    ],
+    "plugins": [
+    ],
+    "rules": [ // definitions of regular-expression based rules
+        {
+            "type": "source-checker",
+            "name": "source-no-normalize",
+            "severity": "warning",
+            "description": "Example rule to ensure that the normalize function is not called.",
+            "note": "",
+            "regexps": [ "\\.normalize\\s*\\(" ]
+        }
+    ],
+    "rulesets": {
+        "javascript-rules": {
+            "source-no-normalize": true,
+            "my-other-rule": false
+        },
+        "webos-translation-rules": { // you can also define rulesets in the webos plugin
+            "rule": true,
+            "resource-quote-style": true
+        }
+    },
+    "filetypes":{
+        "javascript": {
+            "ruleset": [
+                "javascript-rules" // choose the rulesets by the ruleset name
+            ]
+        },
+        "xliff" : {  // last two will be defined by the webos plugin
+            "ruleset": [ 
+                "source", "webos-translation-rules", "webos-source-rules" 
+            ]
+        }
+    },
+    "paths": {
+        "src/**/*.json": {
+            // this defines the file type right here, like an anonymous function in JS
+            "locales": [
+                "en-US",
+                "de-DE",
+                "ja-JP"
+            ],
+            "ruleset": ["source"]
+        },
+        "[a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-Z])?(\.xliff)": "xliff",  // this specifies the file type by file type name
+        "test/testfiles/**/*.js": "javascript"
+    }
+}

--- a/packages/samples-lint/package.json
+++ b/packages/samples-lint/package.json
@@ -1,8 +1,10 @@
 {
-    "name": "ilib-webos-sample",
+    "private": true,
+    "name": "lint-webos-sample",
     "version": "1.0.0",
     "main": "./src/index.js",
     "description": "Sample application that demostrates how to use the ilib-lint tool with python strings",
+    "license": "Apache-2.0",
     "keywords": [
         "internationalization",
         "i18n",
@@ -10,16 +12,9 @@
         "l10n",
         "globalization",
         "g11n",
-        "date",
-        "time",
-        "format",
         "locale",
-        "translation"
+        "lint"
     ],
-    "homepage": "https://github.com/iLib-js/ilib-sample",
-    "bugs": "https://github.com/iLib-js/ilib-sample/issues",
-    "email": "marketing@translationcircle.com",
-    "license": "Apache-2.0",
     "author": {
         "name": "Edwin Hoogerbeets",
         "web": "http://www.translationcircle.com/",
@@ -35,17 +30,12 @@
             "email": "goun.lee@lge.com"
         }
     ],
-    "files": [
-        "src",
-        "README.md",
-        "LICENSE"
-    ],
     "engines": {
         "node": ">=16.11.0"
     },
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/iLib-sample.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
     },
     "scripts": {
         "lint": "ilib-lint -c ilib-lint-config.json -f html-formatter -o webos-result.html",

--- a/packages/samples-lint/package.json
+++ b/packages/samples-lint/package.json
@@ -1,0 +1,60 @@
+{
+    "name": "ilib-webos-sample",
+    "version": "1.0.0",
+    "main": "./src/index.js",
+    "description": "Sample application that demostrates how to use the ilib-lint tool with python strings",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "date",
+        "time",
+        "format",
+        "locale",
+        "translation"
+    ],
+    "homepage": "https://github.com/iLib-js/ilib-sample",
+    "bugs": "https://github.com/iLib-js/ilib-sample/issues",
+    "email": "marketing@translationcircle.com",
+    "license": "Apache-2.0",
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "edwin@translationcircle.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com"
+        },
+        {
+            "name": "Goun Lee",
+            "email": "goun.lee@lge.com"
+        }
+    ],
+    "files": [
+        "src",
+        "README.md",
+        "LICENSE"
+    ],
+    "engines": {
+        "node": ">=16.11.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:iLib-js/iLib-sample.git"
+    },
+    "scripts": {
+        "lint": "ilib-lint -c ilib-lint-config.json -f html-formatter -o webos-result.html",
+        "debug": "node --inspect-brk node_modules/ilib-lint/src/index.js -c ilib-lint-config.json -f html-formatter -o webos-result.html",
+        "clean": "rm webos-result.html",
+        "test": "echo success"
+    },
+    "dependencies": {
+        "ilib-lint": "^2.7.2",
+        "ilib-lint-webos": "workspace:*"
+    }
+}

--- a/packages/samples-lint/sample-A/af-ZA.xliff
+++ b/packages/samples-lint/sample-A/af-ZA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="af-ZA">
+ <file id="sample-A_f1" original="sample-A">
+  <group id="sample-A_g1" name="javascript">
+   <unit id="sample-A_1">
+    <segment>
+     <source>Please set your PIN code from 'Menu > PIN Code'.</source>
+     <target>Stel asseblief u PIN-kode vanaf “Kieslys > PIN-kode”.</target>
+    </segment>
+   </unit>
+  </group>
+ </file>
+</xliff>

--- a/packages/samples-lint/sample-A/de-DE.xliff
+++ b/packages/samples-lint/sample-A/de-DE.xliff
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="de-DE">
+ <file id="sample-A_f1" original="sample-A">
+  <group id="sample-A_g1" name="javascript">
+   <unit id="sample-A_1">
+    <segment>
+     <source>This string has multiple URLs in it: http://www.box.com and http://www.google.com</source>
+     <target>This string is missing one URL: http://www.google.com</target>
+    </segment>
+   </unit>
+   <unit id="sample-A_2">
+     <segment>
+       <source>This string has multiple {params} in it: {sub}</source>
+       <target>This string is missing one URL: {sub}</target>
+     </segment>
+     </unit>
+  </group>
+ </file>
+</xliff>
+

--- a/packages/samples-lint/sample-B/am-ET.xliff
+++ b/packages/samples-lint/sample-B/am-ET.xliff
@@ -1,0 +1,235 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="am-ET">
+ <file id="sample-B_f1" original="sample-B">
+  <group id="sample-B_g1" name="javascript">
+   <unit id="sample-B_1">
+    <segment>
+     <source>{%1} hour(s)</source>
+     <target>{%1} ሰዓት(ታት)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2">
+    <segment>
+     <source>{%1} min(s)</source>
+     <target>{%1} ደቂቃ(ዎች)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3">
+    <segment>
+     <source>{%1} hour(s) {%2} min(s)</source>
+     <target>{%1} ሰዓት(ታት) ከ {%2} ደቂቃ(ዎች)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_4">
+    <segment>
+     <source>USB {portNum}: {vendorName}</source>
+     <target>USB {portNum}: {vendorName}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_28">
+    <segment>
+     <source>Loading...</source>
+     <target>በመጫን ላይ...</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_53">
+    <segment>
+     <source>Wired Connection (Ethernet)</source>
+     <target>የገመድ ግንኙነት (Ethernet)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_76">
+    <segment>
+     <source>Select your remote's cursor speed and appearance.</source>
+     <target>የሪሞትዎን ጠቋሚ ፍጥነት እና ትልቀት ያስተካክሉ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_368">
+    <segment>
+     <source>IPv6 (Automatic)</source>
+     <target>IPv6 (ራስሰር)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_374">
+    <segment>
+     <source>Note:&lt;br>1. If your TV is turned on while Clear Panel Noise is in progress, it will stop the process and you have to start over.&lt;br>2. While processing, a white line may appear in the screen. This is normal when clearing your screen.</source>
+     <target>ማስታወሻ፦&lt;br>1. Clear Panel Noise በሥራ ሂደት ላይ እያለ የእርስዎ TV በርቶ ከሆነ፣ ሂደቱን ያቆማል እንዲሁም እንደገና ከመጀመሪያው መጀመር አለብዎት።&lt;br>2. በሂደት ላይ እያለ፣ በማያ ገጹ ላይ ነጭ መስመር ብቅ ሊል ይችላል። ይህ የእርስዎን ማያ ገጽ በማጽዳት ወቅት ጤናማ ነገር ነው።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_385">
+    <notes>
+     <note>R means Right</note>
+    </notes>
+    <segment>
+     <source>{label} : R{value}</source>
+     <target>{label} : ቀ{value}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_396">
+    <segment>
+     <source>Set TV locks for ratings based on children’s ages.</source>
+     <target>የቴሌቪዥን መሸንጎሪያዎችን የህጻናትን እድሜ መሠረት ላደረገ ደረጃ አሰጣጥ አዘጋጅ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_400">
+    <segment>
+     <source>Select TV's language settings.</source>
+     <target>የቴሌቪዥን/ኖች የቋንቋ ቅንጅቶች ምረጥ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_569">
+    <segment>
+     <source>You can select up to {n} languages</source>
+     <target>እስከ {n} የሚደርሱ ቋንቋዎችን መምረጥ ይችላሉ</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_590">
+    <segment>
+     <source>You can use your Magic Remote to determine the room’s acoustics and optimize your TV’s sound quality based on the results.</source>
+     <target>MAGIC REMOTE በመጠቀም የክፍሉን የድምጽ ማስተጋባት አና በውጤቶቹ መሰረት የቲቪዎን የድምጽ ጥራት ማሰተካከል እና መቆጣጠር ይችላሉ፡፡ </target>
+    </segment>
+   </unit>
+   <unit id="sample-B_592">
+    <segment>
+     <source> (User)</source>
+     <target> (ተጠቃሚ)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_760">
+    <segment>
+     <source>DNS (Manual)</source>
+     <target>DNS (በእጅ የሚሰራ)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_806">
+    <segment>
+     <source>HDMI{port1} port support UHD Deep Color.</source>
+     <target>HDMI{port1 የ ULTRA HD Deep Color የሚደግፍ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1034">
+    <segment>
+     <source>Please accept the request on your {devicename} now.</source>
+     <target>እባክዎ {devicename} ላይ ያለው ጥያቄ ይቀበሉ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1156">
+    <notes>
+     <note>this string for software update</note>
+    </notes>
+    <segment>
+     <source>Update in progress...({n}%)</source>
+     <target>ዝማኔ በሂደት ላይ…({n}%)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1189">
+    <segment>
+     <source>No Signal Power Off (15Min)</source>
+     <target>ምንም የኃይል ማጥፊያ ሲግናል የለም (15ደቂቃ)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2142">
+    <segment>
+     <source>[{deviceName}] will be deleted.</source>
+     <target>[{deviceName}] ይሰረዛል።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1864">
+    <segment>
+     <source>Note:&lt;br>1. If your TV is turned on while Pixel Refresher is in progress, it will stop the process and you have to start over.&lt;br>2. While processing, a white line may appear in the screen. This is normal when clearing your screen.</source>
+     <target>ማስታወሻ፦&lt;br>1. የፒክሰል አዳሽ በሂደት ላይ ሳለ TVዎ በርቶ ከሆነ፤ ሂደቱን ስለሚያስቆመው እንደገና መጀመር ይኖርብዎታል።&lt;br>2. በሂደቱ ጊዜ በማያ ገጹ ላይ ነጭ መስመር ሊታይ ይችላል። ማያ ሰሌዳዎን በማጥራት ጊዜ ይህ ደንብ ነው።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2386">
+    <segment>
+     <source>Enjoy content from the connected devices using the Photo &amp; Video and the Music app in TV.</source>
+     <target>ፎቶ እና ቪድዮ እና በቲቪ ውስጥ ያለው የሙዚቃ መተግበሪ በመጠቀም ይዘትን ከተገናኙ መሳሪያዎች ይደሰቱ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2810">
+    <segment>
+     <source>Left Surround ({n})</source>
+     <target>ግራ አከባቢ ({n})</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2879">
+    <segment>
+     <source>(Default Password: "{variable}")</source>
+     <target>(ነባር የይለፍ ቃል: "{variable}")</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2945">
+    <segment>
+     <source>Time &amp; Timer</source>
+     <target>ሰዓት እና ሰዓት መቆጠሪያ</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2965">
+    <segment>
+     <source>Expert (Dark space, night)</source>
+     <target>ከፍተኛ (ጨለማ ቦታ፣ ማታ)</target>
+    </segment>
+   </unit>
+    <unit id="sample-B_2983">
+    <segment>
+     <source>HDR videos show objects very vividly as if they’re real.</source>
+     <target>HDR ቪዲዮዎች እቃዎችን በጣም እውን እንደሆኑ አድርገው ቁልጭ አድርገው ያሳያሉ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3022">
+    <segment>
+     <source>Signal Level(%)</source>
+     <target>የሲግናል ደረጃ(%)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3050">
+    <segment>
+     <source>To use this feature, change the 'Color Upgrade' menu to 'User Selection'.</source>
+     <target>ይህን ተግባር ለመጠቀም፣ የ 'የቀለም ደረጃ መጨመር' ማውጫን ወደ 'የተጠቃሚ ምርጫ' ይለውጡ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3106">
+    <segment>
+     <source>Choose one from 'Simultaneous Sound Out' and 'Surround Effect'.</source>
+     <target>አንድ ከ 'በአንድ ጊዜ ድምጽ ማንበብ' እና 'ከባቢ ድምፅ' ይምረጡ።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3120">
+    <segment>
+     <source>Right {n}</source>
+     <target>ቀኝ {n}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3203">
+    <segment>
+     <source>Note:&lt;br>1. If your TV is turned on while Pixel Cleaning is in progress, it will stop the process and you have to start over.&lt;br>2. While processing, a white line may appear in the screen. This is normal when clearing your screen.</source>
+     <target>ማስታወሻ፡&lt;br>1. የፒክሰል ማጥራት በሂደት ላይ ሳለ TVዎ በርቶ ከሆነ፤ ሂደቱን ስለሚያስቆመው እንደገና መጀመር ይኖርብዎታል።&lt;br>2. በሂደቱ ጊዜ በማያ ገጹ ላይ ነጭ መስመር ሊታይ ይችላል። ማያ ሰሌዳዎን በማጥራት ወቅት ይህ መደበኛ ነው።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3495" name="basic">
+    <segment>
+     <source>Standard</source>
+     <target>መደበኛ</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3724">
+    <segment>
+     <source>If you don’t consent to the {eula}, your personal information will not be collected.</source>
+     <target>ከ{eula} ጋር ካልተሰማሙ፣ የእርስዎ የግል መረጃ አይሰበሰብም።</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3808">
+    <segment>
+     <source>{%1} hour {%2} min(s)</source>
+     <target>{%1} ሰአት ከ {%2} ደቂቃ(ዎች)</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3800">
+    <segment>
+     <source>[{deviceName}] is connected.</source>
+     <target>[{deviceName}] ተገናኝቷል።</target>
+    </segment>
+   </unit>
+  </group>
+ </file>
+</xliff>

--- a/packages/samples-lint/sample-B/ja-JP.xliff
+++ b/packages/samples-lint/sample-B/ja-JP.xliff
@@ -1,0 +1,327 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ja-JP">
+ <file id="sample-B_f1" original="sample-B">
+  <group id="sample-B_g1" name="javascript">
+   <unit id="sample-B_1">
+    <segment>
+     <source>{%1} hour(s)</source>
+     <target>{%1}時間</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2">
+    <segment>
+     <source>{%1} min(s)</source>
+     <target>{%1}分</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_27">
+    <segment>
+     <source>Monday~Friday</source>
+     <target>月～金</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_62">
+    <segment>
+     <source>Select your remote's cursor speed and appearance.</source>
+     <target>ポインターの表示速度とサイズを選択します。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_94">
+    <notes>
+     <note>L means Left</note>
+    </notes>
+    <segment>
+     <source>{label} : L{value}</source>
+     <target>{label} : 左{value}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_96">
+    <segment>
+     <source>IPv4 (Automatic)</source>
+     <target>IPv4（自動）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_274">
+    <segment>
+     <source>Directed to Older Children (ages 7 and above)</source>
+     <target>年長児向け（7歳以上）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_443">
+    <segment>
+     <source>If the image isn't clear, select another pattern until the picture improves.</source>
+     <target>映像がクリアでない場合は、画質が向上するまで別のパターンを選択してください。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_578">
+    <segment>
+     <source>Saving channels (USB to TV) is completed. TV will be restarted in 5 seconds.</source>
+     <target>チャンネル情報の保存（USBからテレビ）が完了しました。5秒後にテレビが再起動します。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_579">
+    <segment>
+     <source>Saving channels (TV to USB) is completed.</source>
+     <target>チャンネル情報の保存（テレビからUSB）が完了しました。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_590">
+    <segment>
+     <source>You can select up to {n} languages</source>
+     <target>選択できる言語は{n}個までです</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_614">
+    <segment>
+     <source>Add wireless network by manually entering network name (SSID).</source>
+     <target>ネットワーク名 (SSID) を手動で入力して、無線ネットワークを追加して接続します。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_949">
+    <segment>
+     <source>Clear Panel Noise will begin when you switch off your TV. If you're recording something or updating any software, it will wait until those are done as well, which might cause it to take more than 1 hour.</source>
+     <target>テレビの電源をオフにすると、パネルノイズクリアが開始します。&lt;br>録画中やソフトウェアのアップデート中は、それらが完了するまでパネルノイズクリアは開始しません。この場合、処理に１時間以上かかることがあります。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_952">
+    <segment>
+     <source>MAC Address (Wired)</source>
+     <target>MACアドレス（有線）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1033">
+    <segment>
+     <source>Please accept the request on your {devicename} now.</source>
+     <target>{devicename}に対する要求を許可してください。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1034">
+    <segment>
+     <source>{devicename} canceled Wi-Fi Direct connection.</source>
+     <target>{devicename}がWi-Fi Direct接続を取り消しました。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1221">
+    <segment>
+     <source>Import/export your TV's channel list information from/to a connected USB device.</source>
+     <target>テレビのチャンネルリスト情報を接続されているUSBデバイスからインポート/USBデバイスにエクスポートします。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3478">
+    <segment>
+     <source>{num} hr</source>
+     <target>{num} 時間</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3507">
+    <segment>
+     <source>Curvature Mode {num}</source>
+     <target>曲面モード {num}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3509">
+    <notes>
+     <note>[22_additional]_flex_bendable_27</note>
+    </notes>
+    <segment>
+     <source>Level {num}</source>
+     <target>レベル {num}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3536">
+    <segment>
+     <source>Static Mode {num}</source>
+     <target>固定モード {num}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3556">
+    <segment>
+     <source>HDMI(ARC) Device + TV Speaker</source>
+     <target>HDMI(ARC)デバイス + 本体スピーカー</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3559">
+    <segment>
+     <source>Quick Settings > Sound Out > HDMI(ARC) Device Volume</source>
+     <target>[クイック設定] > [スピーカー設定] > [HDMI(ARC)デバイスの音量]</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3560">
+    <segment>
+     <source>Set the current curvature mode 'Off' to omit its value from the curvature button on the remote control.</source>
+     <target>リモコンの曲面ボタンから曲面モードの値を削除する場合は、現在の曲面モードを[オフ]に設定します。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3562">
+    <segment>
+     <source>The TV speaker and an audio device connected to HDMI(ARC) can output sound simultaneously.</source>
+     <target>本体スピーカーとHDMI(ARC)に接続されたオーディオデバイスは同時に音声を出力できます。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3567">
+    <segment>
+     <source>* Note that this feature is not available when 'Audio Guidance' and 'TV Power Sound' is on.</source>
+     <target>* この機能は「音声ガイダンス」と「テレビ電源サウンド」がオンの場合は使用できません。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3568">
+    <segment>
+     <source>* Note that this feature is not available when 'Audio Guidance' is on.</source>
+     <target>* この機能は「音声ガイダンス」がオンの場合は使用できません。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3571">
+    <segment>
+     <source>* The movement may vary depending on the use of 'General > Always Ready'.</source>
+     <target>* 「機器設定」 > 「いつでもOK」の使用状況によって、動作は異なります。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3574">
+    <segment>
+     <source>({mode1} &amp; {mode2})</source>
+     <target>({mode1} &amp; {mode2})</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3620">
+    <segment>
+     <source>You cannot set the Energy Saving Step when 'OLED Care > Care Picture Settings' is enabled.</source>
+     <target>[OLED ケア > ケア映像設定]が有効のときは、省エネステップを設定できません。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3628">
+    <segment>
+     <source>It will read at this pace when choosing {Option Name}.</source>
+     <target>{Option Name} を選択すると、このペースで読みます。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3635">
+    <segment>
+     <source>Select Mode({mode})</source>
+     <target>モード（{mode}）の選択</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3660">
+    <segment>
+     <source>The connection of [{Device Name}] will be disconnected.</source>
+     <target>[{Device Name}]は切断されます。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3661">
+    <segment>
+     <source>'Personalized Picture Wizard' can be set based on the your preference determined by an analysis of image quality attributes such as brightness, color and contrast using AI deep learning technology.</source>
+     <target>[パーソナル・ピクチャー・ウィザード]は、AIのディープラーニング技術によって、明るさ、色、コントラストの画質属性を分析し、お好みに合わせて映像を設定できます。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3669">
+    <segment>
+     <source>Do you want to disable Always Ready?</source>
+     <target>いつでもOKを無効にしますか？</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3710">
+    <segment>
+     <source>{%1}'s Personalized Picture</source>
+     <target>{%1}のパーソナルな映像</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3715">
+    <segment>
+     <source>{LG WOWCAST} Device + TV Speaker</source>
+     <target>{LG WOWCAST}デバイス + 本体スピーカー</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3720">
+    <segment>
+     <source>Do you want to change the sound out settings?</source>
+     <target>スピーカー設定を変更しますか？</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3725">
+    <segment>
+     <source>{Version No.}/{%}MB</source>
+     <target>{Version No.}/{%}MB</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3750">
+    <segment>
+     <source>{iconNick}'s Personalized Picture</source>
+     <target>{iconNick}のパーソナルな映像</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3761">
+    <segment>
+     <source>"Hi, I need help!"</source>
+     <target>「HiG、サポートをお願い！」</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3763">
+    <segment>
+     <source>{%1} Mastering</source>
+     <target>{%1}マスタリング</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3781">
+    <segment>
+     <source>If you don’t consent to the {eula}, your personal information will not be collected.</source>
+     <target>{eula}に同意しない場合、個人情報は収集されません。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3795">
+    <segment>
+     <source>Press Mic button and try saying "I need help"</source>
+     <target>[マイク]ボタンを押して「サポートが必要です」と話してみてください</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3799">
+    <segment>
+     <source>Sao Tome &amp; Principe</source>
+     <target>サントメ・プリンシペ</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3850">
+    <segment>
+     <source>Do you want to disable {func}?</source>
+     <target>{func}を無効にしますか？</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3857">
+    <segment>
+     <source>[{deviceName}] is connected.</source>
+     <target>[{deviceName}]が接続されています。</target>
+    </segment>
+   </unit><unit id="sample-B_3863">
+    <segment>
+     <source>Captions will automatically switch to a position that may not interfere with your viewing when set to 'Automatic'.</source>
+     <target>「自動」に設定すると、自動的に字幕が鑑賞の邪魔にならない位置に切り換わります。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3865">
+    <segment>
+     <source>{%1} hour {%2} min(s)</source>
+     <target>{%1}時間{%2}分</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3867">
+    <segment>
+     <source>{%1} access</source>
+     <target>{%1}アクセス</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_6" name="Billing_242">
+   <notes>
+    <note>[24Init_3rd][Billing]Billing_242</note>
+   </notes>
+   <segment>
+    <source>Please set your PIN code from 'Menu > PIN Code'.</source>
+    <target>「メニュー > PINコード」でPINコードを設定してください。</target>
+   </segment>
+  </unit>
+  <unit id="sample-B_68">
+   <segment>
+    <source>Output sound through an LG audio device connected to the OPTICAL DIGITAL AUDIO OUT port. With this option, you can control the device's volume with your TV remote.</source>
+    <target>光デジタル音声出力ポートに接続されているSound SyncのロゴマークのあるＬＧオーディオデバイスから音声を出力します。このオプションを使用すると、デバイスの音量をテレビのリモコンで操作できます。</target>
+   </segment>
+  </unit>
+  </group>
+ </file>
+</xliff>

--- a/packages/samples-lint/sample-B/ko-KR.xliff
+++ b/packages/samples-lint/sample-B/ko-KR.xliff
@@ -1,0 +1,196 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ko-KR">
+ <file id="sample-B_f1" original="sample-B">
+  <group id="sample-B_g1" name="javascript">
+   <unit id="sample-B_1">
+    <segment>
+     <source>{%1} hour(s)</source>
+     <target>{%1} 시간</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2">
+    <segment>
+     <source>{%1} min(s)</source>
+     <target>{%1} 분</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_23">
+    <notes>
+     <note>popup text - {Device} :Devive Name</note>
+    </notes>
+    <segment>
+     <source>[{Device}] cannot connect to your TV. Please make sure the device is turned on, set to the pairing mode, and try again.</source>
+     <target>[{Device}]와(과) 연결할 수 없습니다. 연결할 기기의 전원이 켜져 있고, 페어링 모드로 설정했는지 확인 후 다시 시도해 주세요.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_35">
+    <notes>
+     <note>help string</note>
+    </notes>
+    <segment>
+     <source>You can set the specialized functions of {label}.</source>
+     <target>{label}의 특화 기능을 설정할 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_39">
+    <segment>
+     <source>• If you can't hear sound through the device, make sure it is working and connected properly.</source>
+     <target>• 작동이 되지 않으면 오디오 기기의 상태를 확인하거나 연결이 되어 있는지 확인해 주세요.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_99">
+    <segment>
+     <source>Suitable for children ages 2-7.</source>
+     <target>2~7세 어린이가 시청하기에 적합합니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_125">
+    <segment>
+     <source>If the image isn't clear, select another pattern until the picture improves.</source>
+     <target>3D 화면 패턴을 변경하면 3D 화질이 향상될 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_213">
+    <segment>
+     <source>Display list of B&amp;O Wireless Speakers that can be connected to your TV.</source>
+     <target>Display list of B&amp;O Wireless Speakers that can be connected to your TV.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_273">
+    <segment>
+     <source>HDMI {port1} and HDMI {port2} ports support ULTRA HD Deep Color.</source>
+     <target>HDMI {port1}, HDMI {port2} 단자는 UHD Deep Color를 지원하며, 이 기능을 켜거나 끌 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_294">
+    <notes>
+     <note>body text</note>
+    </notes>
+    <segment>
+     <source>You can launch the Instant Game Response by setting HDMI ULTRA HD Deep Color "On".</source>
+     <target>HDMI UHD Deep Color를 '켜짐'으로 설정해야 게임 최적화 모드를 실행할 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_371">
+    <segment>
+     <source>Your TV needs to be connected to the network to automatically set your LG Services Country. Do you want to go to Network Settings now to check the connection?</source>
+     <target>LG 서비스 국가를 자동으로 설정하려면 네트워크에 연결해야 합니다. '네트워크 설정'으로 이동해 연결 상태를 확인하시겠습니까?</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_426">
+    <segment>
+     <source>If you turn off 'Quick Start+', you will not be able to turn on your TV with Remote Free Control. Would you like to continue?</source>
+     <target>TV 빨리 켜기 기능을 끄면 원거리 음성인식으로 TV를 켤 수 없습니다. 계속하시겠습니까?</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3511">
+    <segment>
+     <source>If you change the mode to {modeName}, Game Optimizer will be turned off.</source>
+     <target>{modeName}(으)로 변경하면 게임 맞춤 기능이 꺼집니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3512">
+    <segment>
+     <source>'Game Optimizer' mode needs to be set in order to use the game related feature.</source>
+     <target>게임 관련 기능을 사용하려면 '게임 맞춤' 모드로 설정되어야 합니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3515">
+    <segment>
+     <source>Go to 'Sound > Sound Out' or 'Sound > Advanced Settings > Digital Sound Output' to change the setting.</source>
+     <target>설정 변경은 '음향 > 소리 듣기' 혹은 '음향 > 사용자 고급 설정 > 디지털 음향 내보내기'에서 가능합니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3530">
+    <segment>
+     <source>Set the current curvature mode 'Off' to omit its value from the curvature button on the remote control.</source>
+     <target>해당 곡률 모드가 '사용 안 함'으로 설정되면, 리모컨의 곡률 조정 설정에서도 제외됩니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3538">
+    <segment>
+     <source>* Note that this feature is not available when 'Audio Guidance' is on.</source>
+     <target>* 단, '음성으로 메뉴 읽어주기'가 켜져 있으면 이 기능을 사용할 수 없습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3582">
+    <segment>
+     <source>To change Sound Out setting from 'Bluetooth device + TV Speakers', you need to connect Bluetooth device again.</source>
+     <target>'블루투스 기기 + TV 스피커'에서 출력 스피커를 변경할 경우, 블루투스 기기 재연결이 필요합니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3590">
+    <segment>
+     <source>You cannot set the Energy Saving Step when 'OLED Care > Care Picture Settings' is enabled.</source>
+     <target>'올레드 케어 > 케어 화면 설정' 사용 중에는 절전 단계를 설정할 수 없습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3592">
+    <segment>
+     <source>This switches the screen softly without interruptions when other contents with different FPS (Frame Per Second) are played in external devices supporting QMS.</source>
+     <target>QMS를 지원하는 외부 기기에서 초당 프레임수(FPS, Frame Per Second)가 다른 콘텐츠가 재생될 때 화면 끊김 없이 부드럽게 전환해 줍니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3593">
+    <segment>
+     <source>Picture quality processing such as 'Noise Reduction' and 'Trumotion' may not be applied when inputting HDMI PC signals.</source>
+     <target>HDMI PC 신호를 입력할 때 '노이즈 제거', '빠른 화면 맞춤' 등의 화질 처리가 적용되지 않을 수도 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3605">
+    <segment>
+     <source>Select Mode({mode})</source>
+     <target>모드 선택({mode})</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3629">
+    <segment>
+     <source>* Connect a Sound Bar supporting {lgHarmony}, or for users with different levels of hearing impairment, go to 'General > Accessibility > Enjoy TV Sound Together > HDMI(ARC) Device' and set the HDMI(ARC) Device.</source>
+     <target>* {lgHarmony} 지원하는 사운드 바를 연결하거나, 청력이 다른 사용자의 경우 '일반 > 접근성 > TV 소리 함께 듣기 > HDMI(ARC) 기기'를 설정하면 사용할 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3631">
+    <segment>
+     <source>'Personalized Picture Wizard' can be set based on the your preference determined by an analysis of image quality attributes such as brightness, color and contrast using AI deep learning technology.</source>
+     <target>AI 딥러닝 기술을 활용해 좋아하는 밝기, 색, 명암 등 화질을 분석해 화면 모드를 '맞춤 화면'으로 설정할 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3695">
+    <segment>
+     <source>- It is recommended to place the Zero Connect Box within {%1} m from the bottom, {%2} m from the front, and {%3} m from the side of the TV screen.</source>
+     <target>- TV 화면과의 거리는 하단 약 {%1}m, 정면 약 {%2}m, 측면 약 {%3}m 이내를 권장합니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3729">
+    <segment>
+     <source>"Hi, I need help!"</source>
+     <target>"하이 , 도와줘"</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3730">
+    <segment>
+     <source>* Professional settings allow you to fine-tune the expression of a variety of mastering contents.</source>
+     <target>* 전문가용 설정을 통해 여러 마스터링 콘텐츠의 표현력을 세부 조절할 수 있습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3804">
+    <segment>
+     <source>Captions will automatically switch to a position that may not interfere with your viewing when set to 'auto'.</source>
+     <target>'자동'으로 설정하면, 시청에 방해되지 않는 위치로 자동 변경됩니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_75">
+    <segment>
+     <source>Note: The account created from the www.lg.com website does not link with LG SmartThinQ app nor %1 app from the TV.</source>
+     <target>www.lg.com에서 만든 계정은 LG SmartThinQ 모바일 앱이나 TV 내 %1 앱에서 연동해 사용할 수 없습니다.</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_82" name="alert_ageLimit">
+    <segment>
+     <source>You must be at least [age] years old to proceed.</source>
+     <target>계속 진행하려면 [age]세 이상이어야 합니다.</target>
+    </segment>
+   </unit>
+  </group>
+ </file>
+</xliff>

--- a/packages/samples-lint/sample-B/sample.xliff
+++ b/packages/samples-lint/sample-B/sample.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE xliff PUBLIC "-//XLIFF//DTD XLIFF//EN" "http://www.oasis-open.    org/committees/xliff/documents/xliff.dtd">
+ <xliff version="1.0">
+  <file datatype="javascript" original="sample" source-language="en-KR" target-language="ko-KR">
+    <body>
+      <trans-unit id="sample_1">
+        <source>[{deviceName}] will be deleted.</source>
+        <target>[{deviceName}]가 삭제됩니다.</target>
+        <note>String for delete spekaer notification.</note>
+      </trans-unit>
+      <trans-unit id="sample_2">
+        <source>Auto Power Off</source>
+        <target>자동 꺼짐</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>    

--- a/packages/samples-lint/sample-B/zh-Hans-CN.xliff
+++ b/packages/samples-lint/sample-B/zh-Hans-CN.xliff
@@ -1,0 +1,238 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN">
+ <file id="sample-B_f1" original="sample-B">
+  <group id="sample-B_g1" name="javascript">
+   <unit id="sample-B_1">
+    <segment>
+     <source>{%1} hour(s)</source>
+     <target>{%1} 小时</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_58">
+    <segment>
+     <source>Select your remote's cursor speed and appearance.</source>
+     <target>选择您遥控器的光标速度和外观。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_88">
+    <segment>
+     <source>Edit TV channels, set favorites, and manage parental control settings.</source>
+     <target>编辑电视频道、设置喜爱节目并设置家长控制选项。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_141">
+    <segment>
+     <source>IPv4 (Automatic)</source>
+     <target>IPv4（自动）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_156">
+    <notes>
+     <note>L means Left</note>
+    </notes>
+    <segment>
+     <source>{label} : L{value}</source>
+     <target>{label}：左{value}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_163">
+    <segment>
+     <source>IP (Manual)</source>
+     <target>IP（手动）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_281">
+    <segment>
+     <source>press OK button to go to next menu</source>
+     <target>按“确定”按钮以前往下一个菜单</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_371">
+    <segment>
+     <source>Note:&lt;br>1. If your TV is turned on while Clear Panel Noise is in progress, it will stop the process and you have to start over.&lt;br>2. While processing, a white line may appear in the screen. This is normal when clearing your screen.</source>
+     <target>注意：&lt;br>1. 如果在画面优化时打开电视，优化就会停止，您必须重新开始优化。&lt;br>2. 优化过程中，屏幕上会出现一条白线，这在屏幕优化时属于正常现象。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_381">
+    <notes>
+     <note>R means Right</note>
+    </notes>
+    <segment>
+     <source>{label} : R{value}</source>
+     <target>{label}：右{value}</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_430">
+    <segment>
+     <source>If the image isn't clear, select another pattern until the picture improves.</source>
+     <target>如果图像不清晰，请选择另一模式，直至图片更加清晰。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_567">
+    <segment>
+     <source>You can select up to {n} languages</source>
+     <target>最多只能选择 {n} 种语言</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_623">
+    <segment>
+     <source>Set color balance by adjusting color temperature, luminance, and red, green and blue gain controls.</source>
+     <target>通过调整色温、亮度和红色、绿色和蓝色增益控制来设置色彩平衡。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_674">
+    <segment>
+     <source>Audio Out (Line Out)</source>
+     <target>音频输出（线路输出）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_731">
+    <segment>
+     <source>Optimize image quality for fast-moving images (sports and action).</source>
+     <target>优化迅速移动图像（运动图像和动作图像）的图像质量。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_765">
+    <segment>
+     <source>(Version: {l})</source>
+     <target>（版本：{l}）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_997">
+    <segment>
+     <source>Set TV to automatically optimize image quality based on content type. Note: they need to connect to the Internet.</source>
+     <target>根据内容类型设置电视自动优化图片质量。注意：需要连接至网络。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1028">
+    <segment>
+     <source>{devicename} canceled Wi-Fi Direct connection.</source>
+     <target>{devicename} 取消 Wi-Fi Direct。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1206">
+    <segment>
+     <source>Select caption size, color, transparency, and other options for digital broadcasts.</source>
+     <target>选择数字广播的字幕大小、颜色、透明度及其他选项。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1857">
+    <segment>
+     <source>Note:&lt;br>1. If your TV is turned on while Pixel Refresher is in progress, it will stop the process and you have to start over.&lt;br>2. While processing, a white line may appear in the screen. This is normal when clearing your screen.</source>
+     <target>注意：&lt;br>1. 如果在像素刷新器正在运行时打开电视，则此过程将停止，您必须重新开始。&lt;br>2. 在处理过程中，屏幕上可能会出现一条白线，这在屏幕优化时属于正常现象。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1878">
+    <segment>
+     <source>B&amp;O Wireless Speakers</source>
+     <target>B&amp;O 无线扬声器</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1949">
+    <segment>
+     <source>DTS Virtual:X</source>
+     <target>DTS Virtual：X</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1976">
+    <segment>
+     <source>Press the right button to adjust Motion Pro settings.</source>
+     <target>按"右"按钮以调整 Motion Pro 设置。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_1980">
+    <segment>
+     <source>HDMI {port1} port support ULTRA HD Deep Color.</source>
+     <target>HDMI {port1} 端口支持 ULTRA HD Deep Color。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2052">
+    <notes>
+     <note>Voice help</note>
+    </notes>
+    <segment>
+     <source>Use the voice recognition with “Hi”</source>
+     <target>通过说出“Hi”使用语音识别功能</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2056">
+    <segment>
+     <source>There are {n} voice model(s) learned.</source>
+     <target>学习了 {n} 个语音模型。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2690">
+    <segment>
+     <source>Select the Ultra HD Deep Color for HDMI {num} port.</source>
+     <target>选择 HDMI {num} 端口的“Ultra HD Deep Color”。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2948">
+    <segment>
+     <source>Prevent Input Delay (Input Lag) setting will return to Standard if 'Game Optimizer' is not used.</source>
+     <target>如果未使用“游戏优化器”，则“防止输入延迟（输入滞后）”设置将返回“标准”。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_2950">
+    <segment>
+     <source>You can select preferred method of preventing input delay (Input Lag).</source>
+     <target>您可以选择防止输入延迟（输入滞后）的首选方法。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3319">
+    <segment>
+     <source>(User Settings)</source>
+     <target>（用户设置）</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3372">
+    <segment>
+     <source>Check [{name1}] to use {name2} without wallpaper.</source>
+     <target>选中[{name1}]以使用无壁纸的 {name2}。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3392">
+    <segment>
+     <source>Check '{MenuName}' to turn off the TV directly without display of wallpaper by pressing the 'Power' button.</source>
+     <target>选中“{MenuName}”可通过按“电源”按钮直接关闭电视而不显示壁纸。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3418">
+    <segment>
+     <source>{num} mins</source>
+     <target>{num} 分钟</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3687">
+    <segment>
+     <source>{iconNick}'s Personalized Picture</source>
+     <target>{iconNick} 的个性化画面</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3698">
+    <segment>
+     <source>"Hi, I need help!"</source>
+     <target>“Hi，我需要帮助！”</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3794">
+    <segment>
+     <source>[{deviceName}] is connected.</source>
+     <target>[{deviceName}] 已连接。</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3802">
+    <segment>
+     <source>{%1} hour {%2} min(s)</source>
+     <target>{%1} 小时 {%2} 分钟</target>
+    </segment>
+   </unit>
+   <unit id="sample-B_3804">
+    <segment>
+     <source>{%1} access</source>
+     <target>{%1} 访问权限</target>
+    </segment>
+   </unit>
+  </group>
+ </file>
+</xliff>

--- a/packages/samples-lint/script/execute.sh
+++ b/packages/samples-lint/script/execute.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+: <<'END'
+DIR = /home/goun/Source/swp/localization-data
+CONFIG = /home/goun/Source/swp/lintScript/ilib-lint-config.json
+LINTPATH = /home/goun/Source/ilib-samples/lint-webos/node_modules/ilib-lint
+OUTPUTPATH = /home/goun/Source/swp/lintResult-swp
+
+./execute.sh ~/Source/swp/localization-data/ /home/goun/Source/ilib-samples/lint-webos/ilib-lint-config.json /home/goun/Source/ilib-samples/lint-webos/node_modules/.bin/ilib-lint /home/goun/Source/swp/lintResult-swp
+END
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
+DIR=${1?param missing - Specify the localization-data path }
+CONFIG=${2?param missing - Specify the ilib-llint-config.json file path }
+LINTPATH=${3?param missing - Specify the path where the lint tool is intalled }
+OUTPUTPATH=${4?param missing - Specify the path where the output results will be located }
+
+cd $DIR
+echo $PWD
+appCnt=0
+invalidCnt=0
+START_TIME=$(date +%s)
+arrInvalidDir=()
+
+for appDir in `find . -type d`
+do
+  if [ "$appDir" == "." ]; then
+    arrInvalidDir+=($appDir)
+  elif [ "$appDir" == "./git" ]; then
+    arrInvalidDir+=($appDir)
+  else
+    cd $appDir
+    appCnt=$((appCnt+1))
+    echo "<<< ("$appCnt")" $appDir " >>>"
+    node $LINTPATH -c $CONFIG -i -f html-formatter -o $OUTPUTPATH/$appDir-result.html -n $appDir
+    cd ..
+    echo "==========================================================================="
+  fi
+done
+
+echo "---------------------------------------------------------------------------"
+echo "[[ "Number of invalid Directory":" ${#arrInvalidDir[@]} " ]]"
+for value in "${arrInvalidDir[@]}"
+do
+  echo "[" $value "] "
+done
+
+END_TIME=$(date +%s)
+echo "[[ "Number of valid Directory":" $appCnt " ]]"
+echo "<<< It took $(($END_TIME - $START_TIME)) seconds to check xliff files of all app ... >>>"
+echo "---------------------------------- Done ----------------------------------"
+
+#restore $IFS(Internal Field Separator)
+IFS=$SAVEIFS

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,15 @@ importers:
         specifier: 2.28.1
         version: 2.28.1
 
+  packages/samples-lint:
+    dependencies:
+      ilib-lint:
+        specifier: ^2.7.2
+        version: 2.7.2
+      ilib-lint-webos:
+        specifier: workspace:*
+        version: link:../ilib-lint-webos
+
   packages/samples-loctool/webos-c:
     dependencies:
       ilib-loctool-webos-c:
@@ -836,6 +845,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  array.prototype.map@1.0.8:
+    resolution: {integrity: sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==}
+    engines: {node: '>= 0.4'}
+
   array.prototype.reduce@1.0.7:
     resolution: {integrity: sha512-mzmiUCVwtiD4lgxYP8g7IYy8El8p2CSMePvIbTS7gchKir/L1fgJrk0yDKmAX6mnRQFKNADYIk8nNlTris5H1Q==}
     engines: {node: '>= 0.4'}
@@ -1175,6 +1188,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -1462,8 +1478,25 @@ packages:
     resolution: {integrity: sha512-WiNVrKpwdPn1sEqGYXs4DXZBqSTrEAzBWKQKVuoGz+Uh7ru0gvBJUtbm3WLlKEN9elQj0AFTBI3XHG/LOKnaqA==}
     engines: {node: '>=14.0.0'}
 
+  ilib-lint@2.7.2:
+    resolution: {integrity: sha512-WTCjLML8+9/0sLZ8WnSK9iovxlBehf6lWhC2eqh5kqY3mIEmWwqKFZAAq6/D7mtBrVYD2GBYokQ3uSiQkXem8Q==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  ilib-loader@1.3.5:
+    resolution: {integrity: sha512-EeEb652VmB6aAO5nvth3bIHyAapgukxn/7Zyf0mCEhGNCLMv3b6IqbXCRZVrztrgzu/fTLdQKQtq4pO+6ImOCg==}
+
   ilib-locale@1.2.4:
     resolution: {integrity: sha512-3ZIOw45MAmL+uQ1CTt7A/eVOd5wEYlmTWPnQC/GFmGaIxbGvgSD9AuIX1HiFltYQXIBlQWl0yTFf/1yPtfW3ng==}
+
+  ilib-localedata@1.5.2:
+    resolution: {integrity: sha512-qDAOOKFYYguLPT+kj2sVCk97tgPAZztQbmvtUdhHGkWEZX7nm7G97MumaDToATy3N8iccfEO8l0KVxVOTxAEcA==}
+
+  ilib-localeinfo@1.1.0:
+    resolution: {integrity: sha512-F77DV01lWANKqEw1QxEqYNO3Jj3H30kkYMGinMWoCIF18Kb/Gc/aJaaENWlS9kfZkbvfXthcBL7kuswMY+Hjdg==}
+
+  ilib-localematcher@1.3.1:
+    resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
 
   ilib-po@1.1.0:
     resolution: {integrity: sha512-XeIBBbo4YH9I6ltc/d5x9j3CyUHVVmDA632ESKk816fWoHWRcY9p8JhKMrYk3HWW/pLgJVWSa5O9bPJu2nw6GQ==}
@@ -1523,6 +1556,10 @@ packages:
 
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1709,6 +1746,12 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
+
+  iterate-iterator@1.0.2:
+    resolution: {integrity: sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==}
+
+  iterate-value@1.0.2:
+    resolution: {integrity: sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -2109,6 +2152,9 @@ packages:
   opencc-js@1.0.5:
     resolution: {integrity: sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg==}
 
+  options-parser@0.4.0:
+    resolution: {integrity: sha512-KZTzRU3jlv9DVWakQGacYJN3GBP6KY6bb5Gh+QWy88ayADNCj5ql8a4604jBnorQ/bsVja4zjy8q0W8v+71gyg==}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -2227,6 +2273,10 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  promise.allsettled@1.0.7:
+    resolution: {integrity: sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==}
+    engines: {node: '>= 0.4'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -2473,6 +2523,10 @@ packages:
 
   state-toggle@1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
 
   stream-connect@1.0.2:
     resolution: {integrity: sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==}
@@ -3616,6 +3670,16 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  array.prototype.map@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.3
+      define-properties: 1.2.1
+      es-abstract: 1.23.6
+      es-array-method-boxes-properly: 1.0.0
+      es-object-atoms: 1.0.0
+      is-string: 1.1.1
+
   array.prototype.reduce@1.0.7:
     dependencies:
       call-bind: 1.0.8
@@ -4048,6 +4112,18 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.2.6
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
+
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4368,9 +4444,59 @@ snapshots:
 
   ilib-lint-common@3.1.2: {}
 
+  ilib-lint@2.7.2:
+    dependencies:
+      '@formatjs/intl': 2.10.15
+      ilib-common: 1.1.6
+      ilib-lint-common: 3.1.2
+      ilib-locale: 1.2.4
+      ilib-localeinfo: 1.1.0
+      ilib-tools-common: 1.13.0
+      intl-messageformat: 10.7.15
+      json5: 2.2.3
+      log4js: 6.9.1
+      micromatch: 4.0.8
+      options-parser: 0.4.0
+      xml-js: 1.6.11
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  ilib-loader@1.3.5:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      promise.allsettled: 1.0.7
+
   ilib-locale@1.2.4:
     dependencies:
       ilib-env: 1.4.1
+
+  ilib-localedata@1.5.2:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      ilib-loader: 1.3.5
+      ilib-locale: 1.2.4
+      ilib-localematcher: 1.3.1
+      json5: 2.2.3
+
+  ilib-localeinfo@1.1.0:
+    dependencies:
+      '@log4js-node/log4js-api': 1.0.2
+      ilib-common: 1.1.6
+      ilib-env: 1.4.1
+      ilib-locale: 1.2.4
+      ilib-localedata: 1.5.2
+      ilib-localematcher: 1.3.1
+      json5: 2.2.3
+
+  ilib-localematcher@1.3.1:
+    dependencies:
+      ilib-common: 1.1.6
+      ilib-locale: 1.2.4
 
   ilib-po@1.1.0:
     dependencies:
@@ -4446,6 +4572,11 @@ snapshots:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.3
+      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4627,6 +4758,13 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  iterate-iterator@1.0.2: {}
+
+  iterate-value@1.0.2:
+    dependencies:
+      es-get-iterator: 1.1.3
+      iterate-iterator: 1.0.2
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -5277,6 +5415,8 @@ snapshots:
 
   opencc-js@1.0.5: {}
 
+  options-parser@0.4.0: {}
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -5369,6 +5509,15 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  promise.allsettled@1.0.7:
+    dependencies:
+      array.prototype.map: 1.0.8
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.6
+      get-intrinsic: 1.2.6
+      iterate-value: 1.0.2
 
   prompts@2.4.2:
     dependencies:
@@ -5648,6 +5797,11 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   state-toggle@1.0.3: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   stream-connect@1.0.2:
     dependencies:


### PR DESCRIPTION
## Description
 * Move lint-webos sample app from [ilib-samples](https://github.com/iLib-js/ilib-samples) repository
 * Modify package.json file:
   * set private:true
   * modify workspace :"workspace:*"
   * modify git url
 * Update to execute coverage run to include all packages, even if no changes have occurred. Otherwise, the coverage numbers will lack consistency.
 
### Notes
* The latest version of ilib-lint (`2.7.2`) does not work properly in this sample.
* fyi. https://github.com/iLib-js/ilib-mono/pull/78
* remove lint-webos from ilib-samples repo: https://github.com/iLib-js/ilib-samples/pull/32