### PR TITLE
webos-dart: Fix a bug where the string is not extracted when the variable types are defined in args

### DIFF
--- a/.changeset/silent-coats-remain.md
+++ b/.changeset/silent-coats-remain.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-dart": patch
+---
+
+Fix a bug where the string is not extracted when the variable types are defined in args

--- a/.changeset/swift-shirts-give.md
+++ b/.changeset/swift-shirts-give.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+- ilib-loctool-webos-dart:
+  - Fix a bug where the string is not extracted when the variable types are defined in args

--- a/packages/ilib-loctool-webos-dart/DartFile.js
+++ b/packages/ilib-loctool-webos-dart/DartFile.js
@@ -121,7 +121,7 @@ translate("The lowest temperature is {arg1} and the highest temperature is {arg2
 */
 var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
 var reTranslateWithKey = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(key)\s*\:\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
-var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:\s*(\<.*\>)?\s*\{(.*)\}\s*\)/g);
+var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:/g);
 var reTranslatePlural = new RegExp(/translatePlural\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(.*)\)/g);
 var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
 

--- a/packages/ilib-loctool-webos-dart/DartFile.js
+++ b/packages/ilib-loctool-webos-dart/DartFile.js
@@ -115,7 +115,8 @@ DartFile.prototype.makeKey = function(source) {
 /*
 translate("High")
 translate("High", key: "home_connect_210") // will be supported for webos
-translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"}) or translate("The lowest temp is {arg1}", args: <int>{"arg1": 15}),
+translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"})
+translate("The lowest temp is {arg1}", args: <String, int>{"arg1": 15})
 translate("The lowest temperature is {arg1} and the highest temperature is {arg2}.", arg:{"arg1": 15, "arg2": 30})
 */
 var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);

--- a/packages/ilib-loctool-webos-dart/DartFile.js
+++ b/packages/ilib-loctool-webos-dart/DartFile.js
@@ -1,7 +1,7 @@
 /*
  * DartFile.js - plugin to extract resources from a Dart source code file
  *
- * Copyright (c) 2023-2024, JEDLSoft
+ * Copyright (c) 2023-2025, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,12 +115,12 @@ DartFile.prototype.makeKey = function(source) {
 /*
 translate("High")
 translate("High", key: "home_connect_210") // will be supported for webos
-translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"})
+translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"}) or translate("The lowest temp is {arg1}", args: <int>{"arg1": 15}),
 translate("The lowest temperature is {arg1} and the highest temperature is {arg2}.", arg:{"arg1": 15, "arg2": 30})
 */
 var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
 var reTranslateWithKey = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(key)\s*\:\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
-var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:\s*\{(.*)\}\s*\)/g);
+var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:\s*(\<.*\>)?\s*\{(.*)\}\s*\)/g);
 var reTranslatePlural = new RegExp(/translatePlural\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(.*)\)/g);
 var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");
 

--- a/packages/ilib-loctool-webos-dart/test/DartFile.test.js
+++ b/packages/ilib-loctool-webos-dart/test/DartFile.test.js
@@ -286,6 +286,66 @@ describe("dartfile", function() {
         expect(r.getSource()).toBe(" {arg1} app cannot be deleted. ");
         expect(r.getKey()).toBe(" {arg1} app cannot be deleted. ");
     });
+    test("DartFileParseSimpleWithArgWithTypedefined", function() {
+        expect.assertions(5);
+
+        var d = new DartFile({
+            project: p,
+            pathName: undefined,
+            type: dft
+        });
+        expect(d).toBeTruthy();
+
+        d.parse('translate("The lowest temp is {arg1}", args: <String, String>{"arg1": "15"}),');
+
+        var set = d.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("The lowest temp is {arg1}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("The lowest temp is {arg1}");
+        expect(r.getKey()).toBe("The lowest temp is {arg1}");
+    });
+    test("DartFileParseSimpleWithArgWithTypedefined2", function() {
+        expect.assertions(5);
+
+        var d = new DartFile({
+            project: p,
+            pathName: undefined,
+            type: dft
+        });
+        expect(d).toBeTruthy();
+
+        d.parse('translate("The lowest temp is {arg1} and the highest temp is {arg2}.", args: <String, int>{"arg1": 15, "arg2": 30}),');
+
+        var set = d.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r.getKey()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+    });
+    test("DartFileParseSimpleWithArgWithTypedefined3", function() {
+        expect.assertions(5);
+
+        var d = new DartFile({
+            project: p,
+            pathName: undefined,
+            type: dft
+        });
+        expect(d).toBeTruthy();
+
+        d.parse("translate('The lowest temp is {arg1} and the highest temp is {arg2}.', args: <String, int>{'arg1': 15, 'arg2': 30}),");
+
+        var set = d.getTranslationSet();
+        expect(set).toBeTruthy();
+
+        var r = set.getBySource("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+        expect(r.getKey()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+    });
     test("DartFileParseSimpleIgnoreWhitespace", function() {
         expect.assertions(5);
 
@@ -881,7 +941,7 @@ describe("dartfile", function() {
         expect(set.size()).toBe(0);
     });
     test("DartFileTest2", function() {
-        expect.assertions(8);
+        expect.assertions(11);
 
         var d = new DartFile({
             project: p,
@@ -893,7 +953,7 @@ describe("dartfile", function() {
         d.extract();
 
         var set = d.getTranslationSet();
-        expect(set.size()).toBe(4);
+        expect(set.size()).toBe(5);
 
         var r = set.getBySource("Track");
         expect(r).toBeTruthy();
@@ -906,6 +966,11 @@ describe("dartfile", function() {
         expect(r).toBeTruthy();
         expect(r[0].getSource()).toBe("1#At least 1 letter|#At least {num} letters");
         expect(r[0].getKey()).toBe("1#At least 1 letter|#At least {num} letters");
+
+        var r = set.getBySource("first number {arg1}, second number {arg2}, and third number {arg3}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("first number {arg1}, second number {arg2}, and third number {arg3}");
+        expect(r.getKey()).toBe("first number {arg1}, second number {arg2}, and third number {arg3}");
     });
     test("DartFileTest3", function() {
         expect.assertions(17);

--- a/packages/ilib-loctool-webos-dart/test/DartFile.test.js
+++ b/packages/ilib-loctool-webos-dart/test/DartFile.test.js
@@ -1,7 +1,7 @@
 /*
  * DartFile.test.js - test the Dart file handler object.
  *
- * Copyright (c) 2023-2024, JEDLSoft
+ * Copyright (c) 2023-2025, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -973,7 +973,7 @@ describe("dartfile", function() {
         expect(r.getKey()).toBe("first number {arg1}, second number {arg2}, and third number {arg3}");
     });
     test("DartFileTest3", function() {
-        expect.assertions(17);
+        expect.assertions(20);
 
         var d = new DartFile({
             project: p,
@@ -985,7 +985,7 @@ describe("dartfile", function() {
         d.extract();
 
         var set = d.getTranslationSet();
-        expect(set.size()).toBe(5);
+        expect(set.size()).toBe(6);
 
         var r = set.getBySource("WOWCAST ({arg1})");
         expect(r).toBeTruthy();
@@ -1011,6 +1011,11 @@ describe("dartfile", function() {
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
         expect(r.getKey()).toBe("The lowest temp is {arg1} and the highest temp is {arg2}.");
+
+        var r = set.getBySource("Exclusive features for {%model} are all gathered here.");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Exclusive features for {%model} are all gathered here.");
+        expect(r.getKey()).toBe("Exclusive features for {%model} are all gathered here.");
     });
     test("DartPseudoLocalization1", function() {
         expect.assertions(4);

--- a/packages/ilib-loctool-webos-dart/test/testfiles/t2.dart
+++ b/packages/ilib-loctool-webos-dart/test/testfiles/t2.dart
@@ -3,3 +3,4 @@ translate("Track", key: "music_track");
 translate("List", args: {"arg1": "music_track"});
 
 translatePlural('1#At least 1 letter|#At least {num} letters', num);
+translate('first number {arg1}, second number {arg2}, and third number {arg3}', args: <String, int>{'arg1': 15, 'arg2': 30, 'arg3': 47});

--- a/packages/ilib-loctool-webos-dart/test/testfiles/t3.dart
+++ b/packages/ilib-loctool-webos-dart/test/testfiles/t3.dart
@@ -22,3 +22,8 @@ Text(
         'The lowest temp is {arg1} and the highest temp is {arg2}.',
         args: {'arg1': 15, 'arg2': 30}                 ),
     style: Style.textStyle),
+
+static String sn_home_0016(tvModel) => translate(
+        'Exclusive features for {%model} are all gathered here.',
+        args: {'%model': tvModel},    // not extracted
+      );

--- a/packages/samples-loctool/webos-dart/src/msg.dart
+++ b/packages/samples-loctool/webos-dart/src/msg.dart
@@ -20,5 +20,5 @@ translate('The first option is {arg1}.', args: <String, String>{'arg1': 'music'}
 
 static String sn_home_0016(tvModel) => translate(
         'Exclusive features for {%TV_model} are all gathered here.',
-        args: {'%TV_model': tvModel},    // not extracted
+        args: {'%TV_model': tvModel},
       );

--- a/packages/samples-loctool/webos-dart/src/msg.dart
+++ b/packages/samples-loctool/webos-dart/src/msg.dart
@@ -14,3 +14,5 @@ translate(
   '{appName} app cannot be deleted.',
     args: {'appName': 'Settings'}
     ),
+
+translate('The first option is {arg1}.', args: <String, String>{'arg1': 'music'});

--- a/packages/samples-loctool/webos-dart/src/msg.dart
+++ b/packages/samples-loctool/webos-dart/src/msg.dart
@@ -16,3 +16,9 @@ translate(
     ),
 
 translate('The first option is {arg1}.', args: <String, String>{'arg1': 'music'});
+
+
+static String sn_home_0016(tvModel) => translate(
+        'Exclusive features for {%TV_model} are all gathered here.',
+        args: {'%TV_model': tvModel},    // not extracted
+      );

--- a/packages/samples-loctool/webos-dart/test/testResources.js
+++ b/packages/samples-loctool/webos-dart/test/testResources.js
@@ -60,6 +60,7 @@ function testkoKR(){
     var result4 = loadData["Delete All"];
     var result5 = loadData["Search_all"];
     var result6 = loadData["{appName} app cannot be deleted."];
+    var result7 = loadData["The first option is {arg1}."];
                   
     logResults(arguments.callee.name, "앱 목록", result1);
     logResults(arguments.callee.name, "앱 등급", result2);
@@ -67,6 +68,7 @@ function testkoKR(){
     logResults(arguments.callee.name, "모두 삭제", result4);
     logResults(arguments.callee.name, "통합 검색", result5);
     logResults(arguments.callee.name, "{appName}앱은 삭제될 수 없습니다.", result6);
+    logResults(arguments.callee.name, "첫 번째 옵션은 {arg1} 입니다.", result7);
 }
 
 function testfrCA(){

--- a/packages/samples-loctool/webos-dart/test/testResources.js
+++ b/packages/samples-loctool/webos-dart/test/testResources.js
@@ -68,6 +68,7 @@ function testkoKR(){
     var result5 = loadData["Search_all"];
     var result6 = loadData["{appName} app cannot be deleted."];
     var result7 = loadData["The first option is {arg1}."];
+    var result8 = loadData["Exclusive features for {%TV_model} are all gathered here."];
                   
     logResults(arguments.callee.name, "앱 목록", result1);
     logResults(arguments.callee.name, "앱 등급", result2);
@@ -76,6 +77,7 @@ function testkoKR(){
     logResults(arguments.callee.name, "통합 검색", result5);
     logResults(arguments.callee.name, "{appName}앱은 삭제될 수 없습니다.", result6);
     logResults(arguments.callee.name, "첫 번째 옵션은 {arg1} 입니다.", result7);
+    logResults(arguments.callee.name, "{%TV_model}에서만 제공하는 유용한 기능들이 모여 있어요.", result8);
 
     // appinfo
     var result7 = loadDataAppinfoData["title"];

--- a/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
-    <group id="sample-webos-json_g1" name="javascript">
+    <group id="sample-webos-json_g1" name="x-dart">
       <unit id="1">
         <segment>
           <source>Live TV</source>

--- a/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
@@ -52,6 +52,15 @@
         <target>첫 번째 옵션은 {arg1} 입니다.</target>
         </segment>
       </unit>
+      <unit id="676">
+        <notes>
+          <note>notes</note>
+        </notes>
+        <segment>
+          <source>Exclusive features for {%TV_model} are all gathered here.</source>
+          <target>{%TV_model}에서만 제공하는 유용한 기능들이 모여 있어요.</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
@@ -46,6 +46,12 @@
         <target>{appName}앱은 삭제될 수 없습니다.</target>
         </segment>
       </unit>
+      <unit id="6">
+        <segment>
+        <source>The first option is {arg1}.</source>
+        <target>첫 번째 옵션은 {arg1} 입니다.</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
## Description
Fix a bug where the string is not extracted when the variable types are defined in args
for example, `translate('The lowest temp is {arg1} and the highest temp is {arg2}.', args: <String, int>{'arg1': 15, 'arg2': 30})`

Previously, The format that could be extracted when using args was as follows:
`translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"})`
