### PR TITLE
Add missing release note about the webos-dart changes in webos-dist

### DIFF
--- a/.changeset/olive-pants-appear.md
+++ b/.changeset/olive-pants-appear.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": minor
+---
+  
+- ilib-loctool-webos-dart:
+  - Added a feature to enable the Dart filetype to operate in generate mode as well.


### PR DESCRIPTION
- Add missing release note about the webos-dart changes in webos-dist
  The `ilib-loctool-webos-dist` requires a minor version bump because the dependent ilib-loctool-webos-dart plugins have  a minor version update. (add generate mode)