### PR TITLE
webos-json: Update getBaseTranslation not to generate duplicate resources

### DIFF
--- a/.changeset/fair-emus-watch.md
+++ b/.changeset/fair-emus-watch.md
@@ -1,0 +1,6 @@
+---
+"sample-webos-json": patch
+"ilib-loctool-webos-json": patch
+---
+
+Modified _getBaseTranslation to avoid generating duplicate resources

--- a/.changeset/nasty-clouds-smell.md
+++ b/.changeset/nasty-clouds-smell.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-json
+- Modified _getBaseTranslation to avoid generating duplicate resources

--- a/packages/ilib-loctool-webos-json/JsonFile.js
+++ b/packages/ilib-loctool-webos-json/JsonFile.js
@@ -1,7 +1,7 @@
 /*
  * JsonFile.js - plugin to extract resources from a json code file
  *
- * Copyright (c) 2023 JEDLSoft
+ * Copyright (c) 2023,2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-webos-json/JsonFile.js
+++ b/packages/ilib-loctool-webos-json/JsonFile.js
@@ -271,21 +271,31 @@ JsonFile.prototype._addnewResource = function(text, key, locale) {
 
 JsonFile.prototype._getBaseTranslation = function(locale, translations, tester) {
     if (!locale) return;
+
+    var rootLocale = 'en-US';
     var langDefaultLocale = Utils.getBaseLocale(locale);
-    var baseTranslation;
     if (langDefaultLocale === locale) {
-        langDefaultLocale = 'en-US'; // language default locale need to compare with root data
+        langDefaultLocale = rootLocale;
     }
 
-    if (locale !== 'en-US') {
+    var translated = null;
+
+    // Get translation for baseLocale
+    if (locale !== rootLocale) {
         var hashkey = tester.hashKeyForTranslation(langDefaultLocale);
         var alternativeKey = ResourceString.hashKey(tester.getProject(), langDefaultLocale, tester.getKey(), "javascript", tester.getFlavor());
-        var translated = translations.getClean(hashkey) || translations.getClean(alternativeKey);
-        if (translated) {
-            baseTranslation = translated.target;
+        translated = translations.getClean(hashkey) || translations.getClean(alternativeKey);
+
+        // If no translation is found for baseLocale, get translation for 'en-US'
+        if (!translated && langDefaultLocale !== rootLocale) {
+            hashkey = tester.hashKeyForTranslation(rootLocale);
+            alternativeKey = ResourceString.hashKey(tester.getProject(), rootLocale, tester.getKey(), "javascript", tester.getFlavor());
+            translated = translations.getClean(hashkey) || translations.getClean(alternativeKey);
         }
     }
-    return baseTranslation;
+
+    // Return the original string if no translation is found for baseLocales
+    return translated ? translated.target : tester.getKey();
 }
 
 /**

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -1,7 +1,7 @@
 /*
  * JsonAppinfoFile.test.js - test the appinfo.json file type handler object.
  *
- * Copyright (c) 2023,2025 JEDLSoft
+ * Copyright (c) 2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -293,7 +293,7 @@ describe("jsonfile", function() {
         expect(r.getSource()).toBe("Settings@oled");
         expect(r.getKey()).toBe("Settings@oled");
     });
-    test("JsonLocalzeText", function() {
+    test("JsonLocalizeText", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
@@ -324,7 +324,7 @@ describe("jsonfile", function() {
         var expected = '{\n    "title": "사진 &amp; 동영상"\n}';
         expect(actual).toBe(expected);
     });
-    test("JsonLocalzeTextxJsonKey", function() {
+    test("JsonLocalizeTextxJsonKey", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
@@ -355,7 +355,7 @@ describe("jsonfile", function() {
         var expected = '{\n    "title": "사진 &amp; 동영상"\n}';
         expect(actual).toBe(expected);
     });
-    test("JsonLocalzeTextxJsonKey2", function() {
+    test("JsonLocalizeTextxJsonKey2", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
@@ -393,7 +393,7 @@ describe("jsonfile", function() {
         var expected = '{\n    "title": "사진 &amp; 동영상"\n}';
         expect(actual).toBe(expected);
     });
-    test("JsonLocalzeTextxJsonKey3", function() {
+    test("JsonLocalizeTextxJsonKey3", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
@@ -420,7 +420,7 @@ describe("jsonfile", function() {
         var expected = '{\n    "title": "사진 &amp; 동영상2"\n}';
         expect(actual).toBe(expected);
     });
-    test("JsonLocalzeTextMultiple", function() {
+    test("JsonLocalizeTextMultiple", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
@@ -794,7 +794,7 @@ describe("jsonfile", function() {
         expect(ajf.getLocalizedPath("fr-FR")).toBe("localized_json/fr/");
         expect(ajf.getLocalizedPath("fr-CA")).toBe("localized_json/fr/CA/");
     });
-    test("JsonLocalzeTextWithBaseTranslations", function() {
+    test("JsonLocalizeTextWithBaseTranslations", function() {
         expect.assertions(4);
         var ajf = new JsonFile({
             project: p,
@@ -837,17 +837,18 @@ describe("jsonfile", function() {
 
         expect(ajf.getLocalizedPath("fr-FR")).toBe("localized_json/fr/");
     });
-    test("JsonLocalzeTextWithBaseTranslations2", function() {
+    test("JsonLocalizeTextWithBaseTranslations2", function() {
         expect.assertions(2);
         var ajf = new JsonFile({
             project: p,
             type: ajft
         });
         expect(ajf).toBeTruthy();
-        ajf.parse({
-            "id": "app",
-            "title": "Live TV",
-        });
+        ajf.parse(
+            '{\n' +
+            '    "id": "app",\n' +
+            '    "title": "Live TV"\n' +
+            '}\n');
         var translations = new TranslationSet();
 
         // no translation for en-US
@@ -868,17 +869,18 @@ describe("jsonfile", function() {
         var expected = '{}';
         expect(actual).toBe(expected);
     });
-    test("JsonLocalzeTextWithBaseTranslations3", function() {
+    test("JsonLocalizeTextWithBaseTranslations3", function() {
         expect.assertions(6);
         var ajf = new JsonFile({
             project: p,
             type: ajft
         });
         expect(ajf).toBeTruthy();
-        ajf.parse({
-            "id": "app",
-            "title": "Live TV",
-        });
+        ajf.parse(
+            '{\n' +
+            '    "id": "app",\n' +
+            '    "title": "Live TV"\n' +
+            '}\n');
         var translations = new TranslationSet();
 
         // en-US: source !== target

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -1,7 +1,7 @@
 /*
  * JsonAppinfoFile.test.js - test the appinfo.json file type handler object.
  *
- * Copyright (c) 2023 JEDLSoft
+ * Copyright (c) 2023,2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -837,4 +837,88 @@ describe("jsonfile", function() {
 
         expect(ajf.getLocalizedPath("fr-FR")).toBe("localized_json/fr/");
     });
+    test("JsonLocalzeTextWithBaseTranslations2", function() {
+        expect.assertions(2);
+        var ajf = new JsonFile({
+            project: p,
+            type: ajft
+        });
+        expect(ajf).toBeTruthy();
+        ajf.parse({
+            "id": "app",
+            "title": "Live TV",
+        });
+        var translations = new TranslationSet();
+
+        // no translation for en-US
+
+        // kn-IN: source==target
+        var resource2 = new ResourceString({
+            project: "app",
+            source: "Live TV",
+            sourceLocale: "en-KR",
+            key: "Live TV",
+            target: "Live TV",
+            targetLocale: "kn-IN",
+            datatype: "x-json"
+        })
+        translations.add(resource2);
+
+        var actual = ajf.localizeText(translations, "kn-IN");
+        var expected = '{}';
+        expect(actual).toBe(expected);
+    });
+    test("JsonLocalzeTextWithBaseTranslations3", function() {
+        expect.assertions(6);
+        var ajf = new JsonFile({
+            project: p,
+            type: ajft
+        });
+        expect(ajf).toBeTruthy();
+        ajf.parse({
+            "id": "app",
+            "title": "Live TV",
+        });
+        var translations = new TranslationSet();
+
+        // en-US: source !== target
+        var resource = new ResourceString({
+            project: "app",
+            source: "Live TV",
+            sourceLocale: "en-KR",
+            key: "Live TV",
+            target: "(en-US) Live TV",
+            targetLocale: "en-US",
+            datatype: "x-json"
+        })
+        translations.add(resource);
+
+        // no translation for fr-FR
+
+        // fr-CA: source==target
+        var resource3 = new ResourceString({
+            project: "app",
+            source: "Live TV",
+            sourceLocale: "en-KR",
+            key: "Live TV",
+            target: "Live TV",
+            targetLocale: "fr-CA",
+            datatype: "x-json"
+        })
+        translations.add(resource3);
+
+        var actual0 = ajf.localizeText(translations, "en-US");
+        var expected0 = '{\n    "title": "(en-US) Live TV"\n}';
+        expect(actual0).toBe(expected0);
+        var actual1 = ajf.localizeText(translations, "fr-FR");
+        var expected1 = '{}';
+        expect(actual1).toBe(expected1);
+        var actual2 = ajf.localizeText(translations, "fr-CA");
+        var expected2 = '{\n    "title": "Live TV"\n}';
+        expect(actual2).toBe(expected2);
+
+        expect(ajf.getLocalizedPath("en-US")).toBe("localized_json/");
+        expect(ajf.getLocalizedPath("fr-CA")).toBe("localized_json/fr/CA/");
+    });
+
 });

--- a/packages/samples-loctool/webos-json/appinfo.json
+++ b/packages/samples-loctool/webos-json/appinfo.json
@@ -4,6 +4,7 @@
     "type": "web",
     "main": "index.html",
     "title": "Live TV",
+    "title@oled": "Live TV oled",
     "icon": "icon.png",
     "uiRevision": 2,
     "transparent": true,

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "name": "sample-webos-qcardinfo",
+    "name": "sample-webos-json",
     "description": "Sample localization project",
     "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",

--- a/packages/samples-loctool/webos-json/project.json
+++ b/packages/samples-loctool/webos-json/project.json
@@ -33,6 +33,7 @@
             "fr-CA",
             "fr-FR",
             "it-IT",
+            "kn-IN",
             "ko-KR",
             "zh-Hans-CN",
             "zh-Hant-HK",

--- a/packages/samples-loctool/webos-json/test/JsonApp.test.js
+++ b/packages/samples-loctool/webos-json/test/JsonApp.test.js
@@ -91,20 +91,23 @@ describe('test the localization result of webos-json app', () => {
         expect(jsonData["title"]).toBe("(fr) Live TV");
     });
     test("appinfo_jsonsample_test_es_ES", function() {
-        expect.assertions(2);
+        expect.assertions(4);
         filePath = path.join(resourcePath, "es/ES", fileName);
         jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
         expect(jsonData).toBeTruthy();
         expect(jsonData["title"]).toBe("(es-ES) Live TV");
+        expect(jsonData["vendor"]).toBeTruthy();
+        expect(jsonData["vendor"]).toBe("test");
     });
     test("appinfo_jsonsample_test_es_CO", function() {
-        expect.assertions(2);
+        expect.assertions(3);
         filePath = path.join(resourcePath, "es", fileName);
         jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
         expect(jsonData).toBeTruthy();
         expect(jsonData["title"]).toBe("(es-CO) Live TV");
+        expect(jsonData["vendor"]).toBeFalsy();
     });
     test("appinfo_jsonsample_test_it_IT", function() {
         expect.assertions(2);
@@ -138,6 +141,15 @@ describe('test the localization result of webos-json app', () => {
         expect(jsonData).toBeTruthy();
         expect(jsonData["title"]).toBe("直播電視");
     });
+    test("appinfo_jsonsample_test_kn_IN", function() {
+        expect.assertions(3);
+        filePath = path.join(resourcePath, "kn", fileName);
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["title"]).toBe("(kn-IN) Live TV");
+        expect(jsonData["title@oled"]).toBeFalsy();
+    });
     test("qcardinfo_jsonsample_test_ko_KR", function() {
         expect.assertions(3);
         fileName = "qcardinfo.json";
@@ -157,7 +169,7 @@ describe('test the localization result of webos-json app', () => {
         jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
         expect(jsonData).toBeTruthy();
-        expect(jsonData["title"]).toBe("Sports");
+        expect(jsonData["title"]).toBeFalsy();
         expect(jsonData["description"]).toBe("Toutes les informations sportives rassemblées au même endroit");
     });
     test("qcardinfo_jsonsample_test_fr_CA", function() {

--- a/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
@@ -8,6 +8,15 @@
           <target>(es-ES) Live TV</target>
         </segment>
       </unit>
+      <unit id="2">
+        <notes>
+          <note>vendor</note>
+        </notes>
+        <segment>
+          <source>test</source>
+          <target>test</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
@@ -11,7 +11,8 @@
       <unit id="2">
         <notes>
           <note>title@oled</note>
-        </notes>        <segment>
+        </notes>
+        <segment>
           <source>Live TV oled</source>
           <target>Live TV oled</target>
         </segment>

--- a/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
@@ -1,33 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="kn-IN">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">
         <segment>
           <source>Live TV</source>
-          <target>(en-US) Live TV</target>
+          <target>(kn-IN) Live TV</target>
         </segment>
       </unit>
       <unit id="2">
         <notes>
-          <note>vendor</note>
-        </notes>
-        <segment>
-          <source>test</source>
-          <target>(dup) test</target>
-        </segment>
-      </unit>
-      <!-- Leave comments as is
-      <unit id="3">
-        <notes>
           <note>title@oled</note>
-        </notes>
-        <segment>
+        </notes>        <segment>
           <source>Live TV oled</source>
           <target>Live TV oled</target>
         </segment>
       </unit>
-      -->
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
To avoid generating duplicate resources, loctool compares the translation with the base translation.
`_getBaseTranslation` has been improved for cases where the base locale translation does not exist.

getBaseTranslation
1. Return the translation for langDefaultLocale if it exists.
2. If not, return the translation for rootLocale(en-US) if it exists.
3. If neither exists, return the source string.

ex)
1) current locale: kn-IN, no Xliff for en-US
-> baseTranslation: source string
2) current locale: fr-CA, no Xliff for fr-FR
-> baseTranslation: translation for en-US
