### PR TITLE
webos-c: Fix the issue where localizable strings are not extracted when the string value is empty ("")

### DIFF
--- a/.changeset/real-eggs-happen.md
+++ b/.changeset/real-eggs-happen.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-c": patch
+---
+
+Fix the issue where localizable strings are not extracted when the string value is empty ("").

--- a/.changeset/violet-gifts-buy.md
+++ b/.changeset/violet-gifts-buy.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+Fix the issue where localizable strings are not extracted when the string value is empty ("").

--- a/.changeset/violet-gifts-buy.md
+++ b/.changeset/violet-gifts-buy.md
@@ -2,4 +2,5 @@
 "ilib-loctool-webos-dist": patch
 ---
 
-Fix the issue where localizable strings are not extracted when the string value is empty ("").
+ilib-loctool-webos-c
+- Fix the issue where localizable strings are not extracted when the string value is empty ("").

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ coverage/
 # Samples
 resources/
 assets/
-testfiles/
+packages/ilib-loctool-webos-json-resource/testfiles

--- a/packages/ilib-loctool-webos-c/CFile.js
+++ b/packages/ilib-loctool-webos-c/CFile.js
@@ -121,7 +121,7 @@ CFile.prototype.parse = function(data) {
     reGetLocString.lastIndex = 0; // just to be safe
     var result = reGetLocString.exec(data);
     while (result && result.length > 1) {
-        match = result[3] ? result[3]: " "; //Update for the following case support: resBundle_getLocString(_gpstResBundle, "");
+        match = result[3];
         if (match && match.length) {
             this.logger.trace("Found string key: " + this.makeKey(match) + ", string: '" + match + "'");
 
@@ -133,25 +133,23 @@ CFile.prototype.parse = function(data) {
 
             match = CFile.unescapeString(match);
 
-            if (result[3]) {
-                var r = this.API.newResource({
-                    resType: "string",
-                    project: this.project.getProjectId(),
-                    key: match,
-                    sourceLocale: this.project.sourceLocale,
-                    source: match,
-                    autoKey: true,
-                    pathName: this.pathName,
-                    state: "new",
-                    comment: CFile.trimComment(comment),
-                    datatype: this.type.datatype,
-                    index: this.resourceIndex++
-                });
-                this.set.add(r);
-            }
+            var r = this.API.newResource({
+                resType: "string",
+                project: this.project.getProjectId(),
+                key: match,
+                sourceLocale: this.project.sourceLocale,
+                source: match,
+                autoKey: true,
+                pathName: this.pathName,
+                state: "new",
+                comment: CFile.trimComment(comment),
+                datatype: this.type.datatype,
+                index: this.resourceIndex++
+            });
+            this.set.add(r);
         } else {
             this.logger.warn("Warning: Bogus empty string in get string call: ");
-            this.logger.warn("... " + data.substring(result.index, reGetString.lastIndex) + " ...");
+            this.logger.warn("... " + data.substring(result.index, reGetLocString.lastIndex) + " ...");
         }
         result = reGetLocString.exec(data);
     }

--- a/packages/ilib-loctool-webos-c/CFile.js
+++ b/packages/ilib-loctool-webos-c/CFile.js
@@ -1,7 +1,7 @@
 /*
  * CFile.js - plugin to extract resources from a C source code file
  *
- * Copyright (c) 2019-2023, JEDLSoft
+ * Copyright (c) 2019-2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,9 +120,8 @@ CFile.prototype.parse = function(data) {
     // To extract resBundle_getLocString()
     reGetLocString.lastIndex = 0; // just to be safe
     var result = reGetLocString.exec(data);
-    while (result && result.length > 1 && result[3]) {
-        match = result[3];
-
+    while (result && result.length > 1) {
+        match = result[3] ? result[3]: " "; //To enhance the following case: resBundle_getLocString(_gpstResBundle, "");
         if (match && match.length) {
             this.logger.trace("Found string key: " + this.makeKey(match) + ", string: '" + match + "'");
 
@@ -134,20 +133,22 @@ CFile.prototype.parse = function(data) {
 
             match = CFile.unescapeString(match);
 
-            var r = this.API.newResource({
-                resType: "string",
-                project: this.project.getProjectId(),
-                key: match,
-                sourceLocale: this.project.sourceLocale,
-                source: match,
-                autoKey: true,
-                pathName: this.pathName,
-                state: "new",
-                comment: CFile.trimComment(comment),
-                datatype: this.type.datatype,
-                index: this.resourceIndex++
-            });
-            this.set.add(r);
+            if (result[3]) {
+                var r = this.API.newResource({
+                    resType: "string",
+                    project: this.project.getProjectId(),
+                    key: match,
+                    sourceLocale: this.project.sourceLocale,
+                    source: match,
+                    autoKey: true,
+                    pathName: this.pathName,
+                    state: "new",
+                    comment: CFile.trimComment(comment),
+                    datatype: this.type.datatype,
+                    index: this.resourceIndex++
+                });
+                this.set.add(r);
+            }
         } else {
             this.logger.warn("Warning: Bogus empty string in get string call: ");
             this.logger.warn("... " + data.substring(result.index, reGetString.lastIndex) + " ...");

--- a/packages/ilib-loctool-webos-c/CFile.js
+++ b/packages/ilib-loctool-webos-c/CFile.js
@@ -121,7 +121,7 @@ CFile.prototype.parse = function(data) {
     reGetLocString.lastIndex = 0; // just to be safe
     var result = reGetLocString.exec(data);
     while (result && result.length > 1) {
-        match = result[3] ? result[3]: " "; //To enhance the following case: resBundle_getLocString(_gpstResBundle, "");
+        match = result[3] ? result[3]: " "; //Update for the following case support: resBundle_getLocString(_gpstResBundle, "");
         if (match && match.length) {
             this.logger.trace("Found string key: " + this.makeKey(match) + ", string: '" + match + "'");
 

--- a/packages/ilib-loctool-webos-c/test/CFile.test.js
+++ b/packages/ilib-loctool-webos-c/test/CFile.test.js
@@ -883,6 +883,21 @@ describe("cfile", function() {
         var set = cf.getTranslationSet();
         expect(set.size()).toBe(4);
     });
+    test("CFileTest4", function() {
+        expect.assertions(2);
+
+        var cf = new CFile({
+            project: p,
+            pathName: "./t4.c",
+            type: cft
+        });
+        debugger;
+        expect(cf).toBeTruthy();
+        cf.extract();
+
+        var set = cf.getTranslationSet();
+        expect(set.size()).toBe(1);
+    });
     test("CFileNotParseCommentLine", function() {
         expect.assertions(3);
 

--- a/packages/ilib-loctool-webos-c/test/CFile.test.js
+++ b/packages/ilib-loctool-webos-c/test/CFile.test.js
@@ -1,7 +1,7 @@
 /*
  * CFile.test.js - test the c file handler object.
  *
- * Copyright (c) 2019-2021,2023 JEDLSoft
+ * Copyright (c) 2019-2021, 2023, 2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -884,19 +884,21 @@ describe("cfile", function() {
         expect(set.size()).toBe(4);
     });
     test("CFileTest4", function() {
-        expect.assertions(2);
+        expect.assertions(3);
 
         var cf = new CFile({
             project: p,
             pathName: "./t4.c",
             type: cft
         });
-        debugger;
         expect(cf).toBeTruthy();
         cf.extract();
 
         var set = cf.getTranslationSet();
         expect(set.size()).toBe(1);
+
+        var resources = set.getAll();
+        expect(resources[0].getSource()).toBe("* You can watch TV even while updating the software.");
     });
     test("CFileNotParseCommentLine", function() {
         expect.assertions(3);

--- a/packages/ilib-loctool-webos-c/test/testfiles/t4.c
+++ b/packages/ilib-loctool-webos-c/test/testfiles/t4.c
@@ -1,0 +1,2 @@
+localizedStr = resBundle_getLocString(_gpstResBundle, "");
+localizedStr = resBundle_getLocString(_gpstResBundle, "* You can watch TV even while updating the software.");


### PR DESCRIPTION
## Description
Fix the issue where localizable strings are not extracted when the string value is empty ("").
Regarding the following example, the second string is not extracted.
```
localizedStr = resBundle_getLocString(_gpstResBundle, "");
localizedStr = resBundle_getLocString(_gpstResBundle, "* You can watch TV even while updating the software.");

```