### PR TITLE
webos-json-resource: Handle exception for fluttermanifest.json

### DIFF
--- a/.changeset/small-walls-swim.md
+++ b/.changeset/small-walls-swim.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-json-resource
+- Handle exception for fluttermanifest.json and modify its path

--- a/.changeset/wild-tips-begin.md
+++ b/.changeset/wild-tips-begin.md
@@ -1,6 +1,5 @@
 ---
 "ilib-loctool-webos-json-resource": patch
-"ilib-loctool-webos-dist": patch
 ---
 
-ilib-loctool-webos-json-resource - Handle exception for fluttermanifest.json
+Handle exception for fluttermanifest.json and modify its path

--- a/.changeset/wild-tips-begin.md
+++ b/.changeset/wild-tips-begin.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-json-resource": patch
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-json-resource - Handle exception for fluttermanifest.json

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -356,13 +356,11 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
     walk(filePath, "");
     var manifestFilePath = (this.project.getProjectType() === 'webos-dart') ?
                            path.join(filePath, "fluttermanifest.json") : path.join(filePath, "ilibmanifest.json");
-
     var readManifest, data;
     if (fs.existsSync(manifestFilePath)) {
         readManifest = fs.readFileSync(manifestFilePath, {encoding:'utf8'});
         data = JSON.parse(readManifest)
     }
-
     if ((!data || data["generated"] === undefined) && manifest.files.length > 0) {
         for (var i=0; i < manifest.files.length; i++) {
             this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -328,10 +328,13 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
         files: []
     };
 
-    if (!fs.existsSync(filePath)) return;
-
     if (this.project.getProjectType() === 'webos-dart') {
-        filePath = "assets/i18n";
+        filePath = path.join(this.project.root, "assets/i18n");
+    }
+
+    if (!fs.existsSync(filePath)) {
+        this.logger.debug(filePath+" does not exist");
+        return;
     }
 
     function walk(root, dir) {
@@ -353,11 +356,13 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
     walk(filePath, "");
     var manifestFilePath = (this.project.getProjectType() === 'webos-dart') ?
                            path.join(filePath, "fluttermanifest.json") : path.join(filePath, "ilibmanifest.json");
+
     var readManifest, data;
     if (fs.existsSync(manifestFilePath)) {
         readManifest = fs.readFileSync(manifestFilePath, {encoding:'utf8'});
         data = JSON.parse(readManifest)
     }
+
     if ((!data || data["generated"] === undefined) && manifest.files.length > 0) {
         for (var i=0; i < manifest.files.length; i++) {
             this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -329,11 +329,11 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
     };
 
     if (this.project.getProjectType() === 'webos-dart') {
-        filePath = path.join(this.project.root, "assets/i18n");
+        filePath = path.join(this.project.getRoot(), "assets/i18n");
     }
 
     if (!fs.existsSync(filePath)) {
-        this.logger.debug(filePath+" does not exist");
+        this.logger.debug(filePath + " does not exist");
         return;
     }
 

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.js - represents an JSON style resource file
  *
- * Copyright (c) 2019-2024, JEDLSoft
+ * Copyright (c) 2019-2025, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.test.js - test the JavaScript file handler object.
  *
- * Copyright (c) 2019-2024 JEDLSoft
+ * Copyright (c) 2019-2025 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -76,6 +76,42 @@ var p3 = new CustomProject({
     }
 });
 
+var p4 = new CustomProject({
+    id: "flutterHome",
+    projectType: "webos-dart",
+    sourceLocale: "en-KR",
+    resourceDirs: {
+        "json": "assets/i18n"
+        }
+    }, "./testfiles", {
+    dart: {
+        "mappings": {
+            "**/*.dart": {
+                "type": "dart",
+                "template": "[dir]/assets/i18n/[localeUnder].json"
+            }
+        }
+    }
+});
+
+var p5 = new CustomProject({
+    id: "flutterHome",
+    projectType: "webos-dart",
+    sourceLocale: "en-KR",
+    resourceDirs: {
+        "json": "assets/i18n"
+        }
+    }, "./non_existent_dir", {
+    dart: {
+        "mappings": {
+            "**/*.dart": {
+                "type": "dart",
+                "template": "[dir]/assets/i18n/[localeUnder].json"
+            }
+        }
+    }
+});
+
 describe("jsonresourcefile", function() {
     test("JSONResourceFileConstructor", function() {
         expect.assertions(1);
@@ -1038,6 +1074,7 @@ describe("jsonresourcefile", function() {
             locale: "sl-SI"
         });
         expect(jsrf).toBeTruthy();
+        debugger
 
         [
             p2.getAPI().newResource({
@@ -1067,6 +1104,69 @@ describe("jsonresourcefile", function() {
         var actual = jsrf.getContent();
         diff(actual, expected);
 
+        expect(actual).toBe(expected);
+    });
+    test("JSONResourceFileWriteManifest", function() {
+        expect.assertions(5);
+
+        var jsrf = new JSONResourceFile({
+            project: p4,
+            locale: "es-ES"
+        });
+        expect(jsrf).toBeTruthy();
+
+        [
+            p4.getAPI().newResource({
+                type: "string",
+                project: "flutterHome",
+                targetLocale: "es-ES",
+                key: "Good Morning!",
+                sourceLocale: "en-KR",
+                source: "Good Morning!",
+                target: "¡Buenos días!"
+            }),
+        ].forEach(function(res) {
+            jsrf.addResource(res);
+        });
+        var expected =
+            '{\n' +
+            '    "Good Morning!": "¡Buenos días!"\n' +
+            '}';
+
+        var actual = jsrf.getContent();
+        diff(actual, expected);
+
+        jsrf.write();
+        jsrf.writeManifest("resources");
+
+        var dir = path.dirname(jsrf.getResourceFilePath());
+        expect(fs.existsSync(dir)).toBeTruthy();
+        expect(fs.existsSync(path.join(dir, "fluttermanifest.json"))).toBeTruthy();
+        expect(jsrf.isDirty()).toBeTruthy();
+        expect(actual).toBe(expected);
+    });
+    test("JSONResourceFileDoNotWriteManifest", function() {
+        expect.assertions(5);
+
+        var jsrf = new JSONResourceFile({
+            project: p5,
+            locale: "en-US"
+        });
+        expect(jsrf).toBeTruthy();
+
+        var expected =
+            '{}';
+
+        var actual = jsrf.getContent();
+        diff(actual, expected);
+        jsrf.write();
+        jsrf.writeManifest("");
+
+        var dir = path.dirname(jsrf.getResourceFilePath());
+        expect(dir).toBe(path.join(p5.root, "assets/i18n"));
+        expect(fs.existsSync(dir)).toBeFalsy();
+
+        expect(fs.existsSync(path.join(dir, "fluttermanifest.json"))).toBeFalsy();
         expect(actual).toBe(expected);
     });
 });

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -1074,7 +1074,6 @@ describe("jsonresourcefile", function() {
             locale: "sl-SI"
         });
         expect(jsrf).toBeTruthy();
-        debugger
 
         [
             p2.getAPI().newResource({

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -38,6 +38,13 @@ function diff(a, b) {
     }
 }
 
+afterEach(() => {
+    const outputPath = './testfiles';
+    if (fs.existsSync(outputPath)) {
+        fs.rmSync(outputPath, { recursive: true });
+    }
+});
+
 var p = new CustomProject({
     id: "webosApp",
     projectType: "webos-web",
@@ -84,24 +91,6 @@ var p4 = new CustomProject({
         "json": "assets/i18n"
         }
     }, "./testfiles", {
-    dart: {
-        "mappings": {
-            "**/*.dart": {
-                "type": "dart",
-                "template": "[dir]/assets/i18n/[localeUnder].json"
-            }
-        }
-    }
-});
-
-var p5 = new CustomProject({
-    id: "flutterHome",
-    projectType: "webos-dart",
-    sourceLocale: "en-KR",
-    resourceDirs: {
-        "json": "assets/i18n"
-        }
-    }, "./non_existent_dir", {
     dart: {
         "mappings": {
             "**/*.dart": {
@@ -1136,7 +1125,8 @@ describe("jsonresourcefile", function() {
         diff(actual, expected);
 
         jsrf.write();
-        jsrf.writeManifest("resources");
+        var resourceRoot = path.join(p4.getRoot(), "assets/i18n");
+        jsrf.writeManifest(resourceRoot);
 
         var dir = path.dirname(jsrf.getResourceFilePath());
         expect(fs.existsSync(dir)).toBeTruthy();
@@ -1148,7 +1138,7 @@ describe("jsonresourcefile", function() {
         expect.assertions(5);
 
         var jsrf = new JSONResourceFile({
-            project: p5,
+            project: p4,
             locale: "en-US"
         });
         expect(jsrf).toBeTruthy();
@@ -1159,10 +1149,11 @@ describe("jsonresourcefile", function() {
         var actual = jsrf.getContent();
         diff(actual, expected);
         jsrf.write();
-        jsrf.writeManifest("");
+        var resourceRoot = path.join(p4.getRoot(), "assets/i18n");
+        jsrf.writeManifest(resourceRoot);
 
         var dir = path.dirname(jsrf.getResourceFilePath());
-        expect(dir).toBe(path.join(p5.root, "assets/i18n"));
+        expect(dir).toBe(resourceRoot);
         expect(fs.existsSync(dir)).toBeFalsy();
 
         expect(fs.existsSync(path.join(dir, "fluttermanifest.json"))).toBeFalsy();


### PR DESCRIPTION
If the resources for Flutter apps are not generated (no translation), an exception occurs during the build process. This happens because after checking the existence of the resources directory, the path is changed to 'assets/i18n'. And the directory path should include the project root.