### PR TITLE
Modify to generate resources in generate mode at the time of test execution  instead of separate child process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ coverage/
 
 # Samples
 resources/
+resources2/
 assets/
+assets2/
+
 
 # Output of the test
 packages/ilib-loctool-webos-json-resource/testfiles

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,8 +1,4 @@
 coverage:
-  ignore:
-    - "packages/samples-lint"
-    - "packages/ilib-loctool-webos-dist"
-    - "scripts"
   status:
     patch:
       default: yes

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,4 +1,8 @@
 coverage:
+  ignore:
+    - "packages/samples-lint"
+    - "packages/ilib-loctool-webos-dist"
+    - "scripts"
   status:
     patch:
       default: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,4 @@
 coverage:
-  ignore:
-    - "packages/samples-lint"
-    - "packages/ilib-loctool-webos-dist"
-    - "scripts"
   status:
     patch:
       default: yes

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -10,7 +10,7 @@
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
         "loc-generate": "loctool generate -2 -x xliffs --xliffStyle custom --projectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --xliffStyle custom --projectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo --localizeOnly",
-        "clean": "rm -rf *.xliff assets resources",
+        "clean": "rm -rf *.xliff assets assets2 resources",
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -29,11 +29,9 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
     let filePath, jsonData;
 
     beforeAll(async() => {
-        const outputPath = "./assets/i18n";
-        if (fs.existsSync(outputPath)) {
-        fs.rmSync(outputPath, { recursive: true });
+        if (fs.existsSync(resourcePath)) {
+            fs.rmSync(resourcePath, { recursive: true });
         }
-
         const projectSettings = {
             "rootDir": ".",
             "id": "sample-webos-dart",
@@ -69,7 +67,7 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
         const project = ProjectFactory.newProject(projectSettings, appSettings);
         GenerateModeProcess(project);
 
-      }, 50000);
+    }, 50000);
     test("dartsample_generate_test_ko_KR", function() {
         expect.assertions(8);
         filePath = path.join(resourcePath, 'ko.json');

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -17,30 +17,59 @@
  * limitations under the License.
  */
 
-const { exec } = require('child_process');
+const fs = require("fs");
 const path = require('path');
 const { isValidPath, loadData } = require('../../Utils.js');
 
+const ProjectFactory = require("loctool/lib/ProjectFactory.js");
+const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
+
 describe('test the localization result (generate mode) of webos-dart app', () => {
     const resourcePath = 'assets/i18n';
-    const generalOptions = '-2 --xliffStyle custom --localizeOnly';
-    const generateModeOptions = '--projectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json';
-    const locales = '-l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI'
-    const localeInherit = '--localeInherit en-AU:en-GB';
-    const localeMap = '--localeMap es-CO:es,fr-CA:fr';
-
     let filePath, jsonData;
 
     beforeAll(async() => {
-      await new Promise((resolve, reject) => {
-        exec(`npm run clean; loctool generate ${generalOptions} ${generateModeOptions} ${localeMap} ${localeInherit} ${locales}`, (error, stdout, stderr) => {
-          if (error) {
-            return reject(error);
-          }
-          resolve(stdout);
-        });
-      });
-    }, 50000);
+        const outputPath = "./assets/i18n";
+        if (fs.existsSync(outputPath)) {
+        fs.rmSync(outputPath, { recursive: true });
+        }
+
+        const projectSettings = {
+            "rootDir": ".",
+            "id": "sample-webos-dart",
+            "projectType": "webos-dart",
+            "sourceLocale": "en-KR",
+            "resourceDirs" : { "json": "assets/i18n" },
+            "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
+            "plugins": [ "ilib-loctool-webos-dart" ],
+            "xliffStyle": "custom",
+            "xliffVersion": 2,
+        };
+        const appSettings = {
+            xliffsDir: "./xliffs",
+            locales:[
+                "en-US",
+                "en-US",
+                "es-CO",
+                "es-ES",
+                "fr-CA",
+                "fr-FR",
+                "ja-JP",
+                "ko-KR",
+                "sl-SI"
+            ],
+            localeMap: {
+                "es-CO": "es",
+                "fr-CA": "fr"
+            },
+            localeInherit: {
+                "en-AU": "en-GB",
+            }
+        };
+        const project = ProjectFactory.newProject(projectSettings, appSettings);
+        GenerateModeProcess(project);
+
+      }, 50000);
     test("dartsample_generate_test_ko_KR", function() {
         expect.assertions(8);
         filePath = path.join(resourcePath, 'ko.json');
@@ -56,92 +85,92 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
         expect(jsonData["Live TV"]).toBe("현재 방송"); //no source code
     });
     test("dartsample_generate_test_fr_CA", function() {
-      expect.assertions(6);
-      filePath = path.join(resourcePath, 'fr.json');
-      jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect.assertions(6);
+        filePath = path.join(resourcePath, 'fr.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-      expect(jsonData).toBeTruthy();
-      expect(jsonData["App List"]).toBe("Liste des applications");
-      expect(jsonData["App Rating"]).toBe("Évaluation de l'application");
-      expect(jsonData["Back button"]).toBe("Bouton Retour");
-      expect(jsonData["Delete All"]).toBe("Tout supprimer");
-      expect(jsonData["Search_all"]).toBe("Rechercher");
-  });
-  test("dartsample_generate_test_fr_FR", function() {
-    expect.assertions(6);
-    filePath = path.join(resourcePath, 'fr_FR.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("Liste des applications");
+        expect(jsonData["App Rating"]).toBe("Évaluation de l'application");
+        expect(jsonData["Back button"]).toBe("Bouton Retour");
+        expect(jsonData["Delete All"]).toBe("Tout supprimer");
+        expect(jsonData["Search_all"]).toBe("Rechercher");
+    });
+    test("dartsample_generate_test_fr_FR", function() {
+        expect.assertions(6);
+        filePath = path.join(resourcePath, 'fr_FR.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["App List"]).toBe("Liste des applications");
-    expect(jsonData["App Rating"]).toBe("Évaluation de l'application");
-    expect(jsonData["Back button"]).toBe("Bouton Retour");
-    expect(jsonData["Delete All"]).toBe("Tout supprimer");
-    expect(jsonData["Search_all"]).toBe("Recherche");
-  });
-  test("dartsample_generate_test_es_CO", function() {
-    expect.assertions(9);
-    filePath = path.join(resourcePath, 'es.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("Liste des applications");
+        expect(jsonData["App Rating"]).toBe("Évaluation de l'application");
+        expect(jsonData["Back button"]).toBe("Bouton Retour");
+        expect(jsonData["Delete All"]).toBe("Tout supprimer");
+        expect(jsonData["Search_all"]).toBe("Recherche");
+    });
+    test("dartsample_generate_test_es_CO", function() {
+        expect.assertions(9);
+        filePath = path.join(resourcePath, 'es.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["App List"]).toBe("Lista de Aplicaciones");
-    expect(jsonData["App Rating"]).toBe("Clasificación de Aplicación");
-    expect(jsonData["Back button"]).toBe("Botón regresar");
-    expect(jsonData["Delete All"]).toBe("Eliminar Todo");
-    expect(jsonData["Search_all"]).toBe("Buscar");
-    expect(jsonData["plural.demo"].one).toBe("Has pulsado el botón una vez.");
-    expect(jsonData["plural.demo"].two).toBe("Has pulsado el botón dos veces.");
-    expect(jsonData["plural.demo"].other).toBe("Ha pulsado el botón {num} veces.");
-  });
-  test("dartsample_generate_test_es_ES", function() {
-    expect.assertions(6);
-    filePath = path.join(resourcePath, 'es_ES.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("Lista de Aplicaciones");
+        expect(jsonData["App Rating"]).toBe("Clasificación de Aplicación");
+        expect(jsonData["Back button"]).toBe("Botón regresar");
+        expect(jsonData["Delete All"]).toBe("Eliminar Todo");
+        expect(jsonData["Search_all"]).toBe("Buscar");
+        expect(jsonData["plural.demo"].one).toBe("Has pulsado el botón una vez.");
+        expect(jsonData["plural.demo"].two).toBe("Has pulsado el botón dos veces.");
+        expect(jsonData["plural.demo"].other).toBe("Ha pulsado el botón {num} veces.");
+      });
+    test("dartsample_generate_test_es_ES", function() {
+        expect.assertions(6);
+        filePath = path.join(resourcePath, 'es_ES.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["App List"]).toBe("Lista de aplicaciones");
-    expect(jsonData["App Rating"]).toBe("Clasificación de la aplicación");
-    expect(jsonData["Back button"]).toBe("Botón atrás");
-    expect(jsonData["Delete All"]).toBe("Eliminar todo");
-    expect(jsonData["Search_all"]).toBe("Búsqueda");
-  });
-  test("dartsample_generate_test_en_US", function() {
-    expect.assertions(7);
-    filePath = path.join(resourcePath, 'en.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("Lista de aplicaciones");
+        expect(jsonData["App Rating"]).toBe("Clasificación de la aplicación");
+        expect(jsonData["Back button"]).toBe("Botón atrás");
+        expect(jsonData["Delete All"]).toBe("Eliminar todo");
+        expect(jsonData["Search_all"]).toBe("Búsqueda");
+    });
+    test("dartsample_generate_test_en_US", function() {
+        expect.assertions(7);
+        filePath = path.join(resourcePath, 'en.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["App List"]).toBe("App List");
-    expect(jsonData["App Rating"]).toBe("App Rating");
-    expect(jsonData["Back button"]).toBe("Back button");
-    expect(jsonData["Delete All"]).toBe("Delete All");
-    expect(jsonData["Search_all"]).toBe("Search");
-    expect(jsonData["{appName} app cannot be deleted."]).toBe("{appName} app cannot be deleted.");
-  });
-  test("dartsample_generate_test_ja_JP", function() {
-    expect.assertions(7);
-    filePath = path.join(resourcePath, 'ja.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("App List");
+        expect(jsonData["App Rating"]).toBe("App Rating");
+        expect(jsonData["Back button"]).toBe("Back button");
+        expect(jsonData["Delete All"]).toBe("Delete All");
+        expect(jsonData["Search_all"]).toBe("Search");
+        expect(jsonData["{appName} app cannot be deleted."]).toBe("{appName} app cannot be deleted.");
+    });
+    test("dartsample_generate_test_ja_JP", function() {
+        expect.assertions(7);
+        filePath = path.join(resourcePath, 'ja.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["App List"]).toBe("アプリリスト");
-    expect(jsonData["App Rating"]).toBe("アプリの評価");
-    expect(jsonData["Back button"]).toBe("[戻る]ボタン");
-    expect(jsonData["Delete All"]).toBe("すべて削除");
-    expect(jsonData["Search_all"]).toBe("検索");
-    expect(jsonData["Time"]).toBe("時刻"); // no source code
-  });
-  test("dartsample_generate_test_sl_SI", function() {
-    expect.assertions(6);
-    filePath = path.join(resourcePath, 'sl.json');
-    jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["App List"]).toBe("アプリリスト");
+        expect(jsonData["App Rating"]).toBe("アプリの評価");
+        expect(jsonData["Back button"]).toBe("[戻る]ボタン");
+        expect(jsonData["Delete All"]).toBe("すべて削除");
+        expect(jsonData["Search_all"]).toBe("検索");
+        expect(jsonData["Time"]).toBe("時刻"); // no source code
+    });
+    test("dartsample_generate_test_sl_SI", function() {
+        expect.assertions(6);
+        filePath = path.join(resourcePath, 'sl.json');
+        jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
-    expect(jsonData).toBeTruthy();
-    expect(jsonData["Search_all"]).toBe("Iskanje");
-    expect(jsonData["1#At least 1 letter|#At least {num} letters"].one).toBe("Vsaj {num} znak");
-    expect(jsonData["1#At least 1 letter|#At least {num} letters"].two).toBe("Vsaj {num} znaka");
-    expect(jsonData["1#At least 1 letter|#At least {num} letters"].few).toBe("Vsaj {num} znake");
-    expect(jsonData["1#At least 1 letter|#At least {num} letters"].other).toBe("Vsaj {num} znakov");
-  });
+        expect(jsonData).toBeTruthy();
+        expect(jsonData["Search_all"]).toBe("Iskanje");
+        expect(jsonData["1#At least 1 letter|#At least {num} letters"].one).toBe("Vsaj {num} znak");
+        expect(jsonData["1#At least 1 letter|#At least {num} letters"].two).toBe("Vsaj {num} znaka");
+        expect(jsonData["1#At least 1 letter|#At least {num} letters"].few).toBe("Vsaj {num} znake");
+        expect(jsonData["1#At least 1 letter|#At least {num} letters"].other).toBe("Vsaj {num} znakov");
+    });
 });

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -29,8 +29,9 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
     let filePath, jsonData;
 
     beforeAll(async() => {
-        if (fs.existsSync(resourcePath)) {
-            fs.rmSync(resourcePath, { recursive: true });
+        const outputPath = "./assets/i18n";
+        if (fs.existsSync(outputPath)) {
+            fs.rmSync(outputPath, { recursive: true });
         }
         const projectSettings = {
             "rootDir": ".",

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -25,11 +25,11 @@ const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
 describe('test the localization result (generate mode) of webos-dart app', () => {
-    const resourcePath = 'assets/i18n';
+    const resourcePath = 'assets2/i18n';
     let filePath, jsonData;
 
     beforeAll(async() => {
-        const outputPath = "./assets/i18n";
+        const outputPath = "./assets2/i18n";
         if (fs.existsSync(outputPath)) {
             fs.rmSync(outputPath, { recursive: true });
         }
@@ -38,7 +38,7 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
             "id": "sample-webos-dart",
             "projectType": "webos-dart",
             "sourceLocale": "en-KR",
-            "resourceDirs" : { "json": "assets/i18n" },
+            "resourceDirs" : { "json": "assets2/i18n" },
             "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
             "plugins": [ "ilib-loctool-webos-dart" ],
             "xliffStyle": "custom",

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "loc": "loctool -2 --xliffStyle custom --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle custom --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
-        "clean": "rm -rf *.xliff resources",
+        "clean": "rm -rf *.xliff resources resources2",
         "loc-generate": "loctool generate -2 -x xliffs --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json  --projectId sample-webos-js -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
         "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 -x xliffs --projectType webos-js --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
         "coverage": "pnpm test --coverage",

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -16,28 +16,63 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const { exec } = require('child_process');
+
+const fs = require("fs");
 const path = require('path');
 const ResBundle = require("ilib/lib/ResBundle");
 const defaultRSPath = path.join(process.cwd(), "resources");
 const { isExistKey } = require('../../Utils.js');
 
-describe('test the localization result (generate mode) of webos-js app', () => {
-    const generalOptions = '-2 --xliffStyle custom --localizeOnly';
-    const generateModeOptions = '--projectType webos-js --projectId sample-webos-js --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json';
-    const locales = '-l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW';
-    const localeInherit = '--localeInherit en-AU:en-GB,en-JP:en-GB';
-    const localeMap = '--localeMap es-CO:es,fr-CA:fr';
+const ProjectFactory = require("loctool/lib/ProjectFactory.js");
+const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
+describe('test the localization result (generate mode) of webos-js app', () => {
     beforeAll(async() => {
-      await new Promise((resolve, reject) => {
-        exec(`npm run clean; loctool generate ${generalOptions} ${generateModeOptions} ${localeMap} ${localeInherit} ${locales}`, (error, stdout, stderr) => {
-          if (error) {
-            return reject(error);
-          }
-          resolve(stdout);
-        });
-      });
+        const outputPath = "./resources";
+        if (fs.existsSync(outputPath)) {
+            fs.rmSync(outputPath, { recursive: true });
+        }
+        const projectSettings = {
+            "rootDir": ".",
+            "id": "sample-webos-js",
+            "projectType": "webos-js",
+            "sourceLocale": "en-KR",
+            "resourceDirs" : { "json": "resources" },
+            "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
+            "plugins": [ "ilib-loctool-webos-javascript" ],
+            "xliffStyle": "custom",
+            "xliffVersion": 2,
+        };
+        const appSettings = {
+            xliffsDir: "./xliffs",
+            locales:[
+                "as-IN",
+                "de-DE",
+                "en-AU",
+                "en-US",
+                "en-GB",
+                "en-JP",
+                "es-ES",
+                "es-CO",
+                "fr-CA",
+                "fr-FR",
+                "ja-JP",
+                "ko-KR",
+                "ko-US",
+                "ko-TW"
+            ],
+            localeMap: {
+                "es-CO": "es",
+                "fr-CA": "fr"
+            },
+            localeInherit: {
+                "en-AU": "en-GB",
+                "en-JP": "en-GB",
+            }
+        };
+        const project = ProjectFactory.newProject(projectSettings, appSettings);
+        GenerateModeProcess(project);
+
     }, 50000);
     test("jssample_generate_test_ko_KR", function() {
         expect.assertions(6);

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -28,9 +28,8 @@ const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
 describe('test the localization result (generate mode) of webos-js app', () => {
     beforeAll(async() => {
-        const outputPath = "./resources";
-        if (fs.existsSync(outputPath)) {
-            fs.rmSync(outputPath, { recursive: true });
+        if (fs.existsSync(defaultRSPath)) {
+            fs.rmSync(defaultRSPath, { recursive: true });
         }
         const projectSettings = {
             "rootDir": ".",

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -28,8 +28,9 @@ const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
 describe('test the localization result (generate mode) of webos-js app', () => {
     beforeAll(async() => {
-        if (fs.existsSync(defaultRSPath)) {
-            fs.rmSync(defaultRSPath, { recursive: true });
+        const outputPath = "./resources";
+        if (fs.existsSync(outputPath)) {
+            fs.rmSync(outputPath, { recursive: true });
         }
         const projectSettings = {
             "rootDir": ".",

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -20,7 +20,7 @@
 const fs = require("fs");
 const path = require('path');
 const ResBundle = require("ilib/lib/ResBundle");
-const defaultRSPath = path.join(process.cwd(), "resources");
+const defaultRSPath = path.join(process.cwd(), "resources2");
 const { isExistKey } = require('../../Utils.js');
 
 const ProjectFactory = require("loctool/lib/ProjectFactory.js");
@@ -28,7 +28,7 @@ const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
 describe('test the localization result (generate mode) of webos-js app', () => {
     beforeAll(async() => {
-        const outputPath = "./resources";
+        const outputPath = "./resources2";
         if (fs.existsSync(outputPath)) {
             fs.rmSync(outputPath, { recursive: true });
         }
@@ -37,7 +37,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
             "id": "sample-webos-js",
             "projectType": "webos-js",
             "sourceLocale": "en-KR",
-            "resourceDirs" : { "json": "resources" },
+            "resourceDirs" : { "json": "resources2" },
             "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
             "plugins": [ "ilib-loctool-webos-javascript" ],
             "xliffStyle": "custom",


### PR DESCRIPTION
- Modify to generate resources in generate mode through code to check for the test (webos-js, webos-dart)
  -  From an integration testing perspective for apps, previously loctool was executed as a separate process, but now it is configured to run at the time of test execution.