### PR TITLE
webos-javascript: Fix the issues where the strings were not trimmed and the comments were deleted incorrectly

### DIFF
--- a/.changeset/calm-hornets-repair.md
+++ b/.changeset/calm-hornets-repair.md
@@ -1,0 +1,8 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-javascript:
+ - Fixed the issues where the localizable strings were not extracted properly.
+   - Removed the incorrectly comments
+   - Missed handling the unescaped string for the new line character.

--- a/.changeset/chatty-radios-march.md
+++ b/.changeset/chatty-radios-march.md
@@ -1,0 +1,7 @@
+---
+"ilib-loctool-webos-javascript": patch
+---
+
+Fixed the issues where the localizable strings were not extracted properly.
+ - Removed the incorrectly comments
+ - Missed handling the unescaped string for the new line character.

--- a/packages/ilib-loctool-webos-javascript/CHANGELOG.md
+++ b/packages/ilib-loctool-webos-javascript/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- f4beb98: Fix the issue where the comments are incorrectly removed, the localizable string are not extracted properly.
+- f4beb98: Fixed the issue where the comments are incorrectly removed, the localizable string are not extracted properly.
 
 ## 1.10.8
 
@@ -19,7 +19,7 @@
 ### Patch Changes
 
 - 079439a: Updated dependencies. (loctool: 2.28.1)
-- 96e8bf4: Update dependencies. (loctool: 2.28.1)
+- 96e8bf4: Updated dependencies. (loctool: 2.28.1)
 - Updated dependencies [079439a]
   - ilib-loctool-webos-json-resource@1.7.1
 
@@ -139,7 +139,7 @@
 
 ## 1.4.5
 
-- Update dependent module version to have the latest one.(loctool: 2.16.2)
+- Updated dependent module version to have the latest one.(loctool: 2.16.2)
 
 ## 1.4.4
 
@@ -176,4 +176,4 @@
 ## 1.1.0
 
 - Supported xliff 2.0 style
-  - Update code to return translation data properly with xliff 2.0 format
+  - Updated code to return translation data properly with xliff 2.0 format

--- a/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
+++ b/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
@@ -50,6 +50,7 @@ JavaScriptFile.unescapeString = function(string) {
     var unescaped = string;
 
     unescaped = unescaped.
+        replace(/\\n/g, "").                // line continuation
         replace(/^\\\\/, "\\").             // unescape backslashes
         replace(/([^\\])\\\\/g, "$1\\").
         replace(/^\\'/, "'").               // unescape quotes

--- a/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
+++ b/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
@@ -94,8 +94,8 @@ JavaScriptFile.trimComments = function(data) {
     // comment style: // , /* */ single, multi line
     var trimData = data.replace(/(?<!https?:)\/\/\s*((?!i18n))\S*$/gm, "").
                     replace(/(?<!https?:)\/\/\s*((?!i18n).)*[\$\\n]/g, "").
-                    replace(/\/\*+([^*]|\*(?!\/))*\*+\//g, "").
-                    replace(/\/\*(.*)\*\//g, "");
+                    replace(/(?<!\/)\/\*+([^*]|\*(?!\/))*\*+\//g, "").
+                    replace(/(?<!\/)\/\*(.*)\*\//g, "");
     return trimData;
 };
 

--- a/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
@@ -860,6 +860,24 @@ describe("javascriptfile", function() {
         var set = j.getTranslationSet();
         expect(set.size()).toBe(1);
     });
+    test("JavaScriptFileParsewithNewLine", function() {
+        expect.assertions(4);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        expect(j).toBeTruthy();
+        j.parse('toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})');
+
+        var set = j.getTranslationSet();
+
+        r = set.getBySource("IPv6 e.g.: \n{ipAddress}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("IPv6 e.g.: \n{ipAddress}");
+        expect(set.size()).toBe(1);
+    });
     test("JavaScriptFileParsePunctuationBeforeRB", function() {
         expect.assertions(9);
 

--- a/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
@@ -1128,6 +1128,30 @@ describe("javascriptfile", function() {
         expect(r.getSource()).toBe("Control smart home IoT devices. See https://lge.com/smarthome for details.");
         expect(r.getKey()).toBe("Control smart home IoT devices. See https://lge.com/smarthome for details.");
     });
+    test("JavaScriptFileTest6", function() {
+        expect.assertions(8);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: "./js/t6.js",
+            type: jsft
+        });
+        expect(j).toBeTruthy();
+        debugger;
+        j.extract();
+        var set = j.getTranslationSet();
+        expect(set.size()).toBe(2);
+
+        var r = set.getBySource("My Playlist");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("My Playlist");
+        expect(r.getKey()).toBe("My Playlist");
+
+        var r = set.getBySource("Bluetooth");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Bluetooth");
+        expect(r.getKey()).toBe("Bluetooth");
+    });
     test("JavaScriptFileNotParseComment", function() {
         expect.assertions(2);
 

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/js/t6.js
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/js/t6.js
@@ -1,0 +1,28 @@
+
+const checkDeviceList = (list, bAddMyplaylist, rtl) => {
+	sampleMusicDevice = temp.splice(temp.length - 1, 1);
+	filteredDevices = temp.sort(compare);
+	//* Order by Port Number
+
+	const
+		myPlaylistObj = {
+			caption: $L('My Playlist'),	// i18n This string is for My Playlist in Select Music Popup
+			deviceId: 'playlist',
+			deviceType: 'playlist'
+		},
+		blueToothObj = {
+			caption: $L('Bluetooth'),
+			deviceId: 'bluetooth',
+			deviceType: 'bluetooth'
+		};
+	if (bAddMyplaylist) {
+		filteredDevices.unshift(myPlaylistObj);
+	}
+	filteredDevices.push(blueToothObj);
+	return {filteredDevices, mobileTVPlusList};
+};
+
+/* ActionCreatror - getThumbnail of TNM */
+const getListThumbnailAction = (res, item) => (dispatch, getState) => {
+	// encode thumbanil path
+}

--- a/packages/samples-loctool/webos-js/src/msg.js
+++ b/packages/samples-loctool/webos-js/src/msg.js
@@ -88,6 +88,8 @@ export function findMsgByCode3 (code) {
         case 13:
             $L("TV On Screen");
             break;
+        case 14:
+            toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
         default:
             msg.reason = $L('MAC Address'); // xliff_target trim
             break;

--- a/packages/samples-loctool/webos-js/test/JsApp.test.js
+++ b/packages/samples-loctool/webos-js/test/JsApp.test.js
@@ -40,7 +40,7 @@ describe('test the localization result of webos-js app', () => {
         });
     }, 50000);
     test("jssample_test_ko_KR", function() {
-        expect.assertions(6);
+        expect.assertions(7);
         let rb = new ResBundle({
             locale:"ko-KR",
             basePath : defaultRSPath
@@ -50,6 +50,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("Time Settings").toString()).toBe("[App] 시간 설정");
         expect(rb.getString("High", "volumeModeHigh").toString()).toBe("높음");
         expect(rb.getString("TV On Screen").toString()).toBe("TV 켜짐 화면");
+        expect(rb.getString("IPv6 e.g.: {ipAddress}").toString()).toBe("IPv6 예시: {ipAddress}");
 
         // common data
         expect(rb.getString("Please enter password.").toString()).toBe("[common] 비밀번호를 입력해 주세요.");

--- a/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
@@ -74,6 +74,12 @@
           <target>TV 켜짐 화면</target>
         </segment>
       </unit>
+      <unit id="177">
+        <segment>
+          <source>IPv6 e.g.: {ipAddress}</source>
+          <target>IPv6 예시: {ipAddress}</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
### Description
Fixed the issues where the localizable strings were not extracted properly.
#### case1)
Removed the incorrectly comments
i.e:
```
//* Order by Port Number
.....
 caption: $L('My Playlist'),
 caption: $L('Bluetooth'),
........
/* ActionCreatror - getThumbnail of TNM */
```
#### case2) 
Missed handling the unescaped string for the new line character.
i.e:
```
toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
```