### PR TITLE
webos-javascript: Fix to correctly handle escape character when making key

### DIFF
--- a/.changeset/breezy-bats-decide.md
+++ b/.changeset/breezy-bats-decide.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-javascript": patch
+---
+
+Fixed to correctly handle escape character when making key

--- a/.changeset/four-jeans-do.md
+++ b/.changeset/four-jeans-do.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-javascript:
+- Fixed to correctly handle escape character when making key.

--- a/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
+++ b/packages/ilib-loctool-webos-javascript/JavaScriptFile.js
@@ -76,8 +76,7 @@ JavaScriptFile.cleanString = function(string) {
 
     unescaped = unescaped.
         replace(/\\[btnfr]/g, " ").
-        replace(/[ \n\t\r\f]+/g, " ").
-        trim();
+        replace(/[ \n\t\r\f]+/g, " ");
 
     return unescaped;
 };
@@ -111,7 +110,7 @@ JavaScriptFile.trimComments = function(data) {
  * @returns {String} a unique key for this string
  */
 JavaScriptFile.prototype.makeKey = function(source) {
-    return JavaScriptFile.unescapeString(source).replace(/\s+/gm, ' ');
+    return JavaScriptFile.cleanString(source).replace(/\s+/gm, ' ');
 };
 
 var reGetStringBogusConcatenation1 = new RegExp(/\.getString(JS)?\s*\(\s*("[^"]*"|'[^']*')\s*\+/g);

--- a/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/JavaScriptFile.test.js
@@ -1110,6 +1110,29 @@ describe("javascriptfile", function() {
         expect(r.getSource()).toBe("Control smart home IoT devices. See https://lge.com/smarthome for details.");
         expect(r.getKey()).toBe("Control smart home IoT devices. See https://lge.com/smarthome for details.");
     });
+    test("JavaScriptFileTestTemp", function() {
+        expect.assertions(8);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: "./js/t7.js",
+            type: jsft
+        });
+        expect(j).toBeTruthy();
+        j.extract();
+        var set = j.getTranslationSet();
+        expect(set.size()).toBe(2);
+
+        var r = set.getBySource("IPv6 e.g.: \\n{ipAddress}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("IPv6 e.g.: \\n{ipAddress}");
+        expect(r.getKey()).toBe("IPv6 e.g.: {ipAddress}");
+
+        var r = set.getBySource("example: \\t{address}");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("example: \\t{address}");
+        expect(r.getKey()).toBe("example: {address}");
+    });
     test("JavaScriptFileNotParseComment", function() {
         expect.assertions(2);
 

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/js/t7.js
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/js/t7.js
@@ -1,0 +1,4 @@
+ case 14:
+     toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
+
+($L("example: \t{address}"))

--- a/packages/samples-loctool/webos-js/src/msg.js
+++ b/packages/samples-loctool/webos-js/src/msg.js
@@ -88,6 +88,10 @@ export function findMsgByCode3 (code) {
         case 13:
             $L("TV On Screen");
             break;
+        case 14:
+            toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
+        case 15:
+            toIString($L("IPv4 e.g.: \t{ip4Address}")).format({ipAddress: "123.123.456.456"})
         default:
             msg.reason = $L('MAC Address'); // xliff_target trim
             break;

--- a/packages/samples-loctool/webos-js/test/JsApp.test.js
+++ b/packages/samples-loctool/webos-js/test/JsApp.test.js
@@ -40,7 +40,7 @@ describe('test the localization result of webos-js app', () => {
         });
     }, 50000);
     test("jssample_test_ko_KR", function() {
-        expect.assertions(6);
+        expect.assertions(8);
         let rb = new ResBundle({
             locale:"ko-KR",
             basePath : defaultRSPath
@@ -50,6 +50,8 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("Time Settings").toString()).toBe("[App] 시간 설정");
         expect(rb.getString("High", "volumeModeHigh").toString()).toBe("높음");
         expect(rb.getString("TV On Screen").toString()).toBe("TV 켜짐 화면");
+        expect(rb.getString("IPv6 e.g.: {ipAddress}").toString()).toBe("IPv6 예시: {ipAddress}");
+        expect(rb.getString("IPv4 e.g.: {ip4Address}").toString()).toBe("IPv4 예시: {ip4Address}");
 
         // common data
         expect(rb.getString("Please enter password.").toString()).toBe("[common] 비밀번호를 입력해 주세요.");

--- a/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
@@ -74,6 +74,18 @@
           <target>TV 켜짐 화면</target>
         </segment>
       </unit>
+      <unit id="177">
+        <segment>
+          <source>IPv6 e.g.: {ipAddress}</source>
+          <target>IPv6 예시: {ipAddress}</target>
+        </segment>
+      </unit>
+      <unit id="178">
+        <segment>
+          <source>IPv4 e.g.: {ip4Address}</source>
+          <target>IPv4 예시: {ip4Address}</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>


### PR DESCRIPTION
#### Description
Fixed to correctly handle escape character when making key
- source : original source should not be manipulated except escaping work
- key: need to handle escape string. It is for searching translation data. trim is not allowed.

##### i.e
```
toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
```