### PR TITLE
webos-javascript: Add integration test cases to improve Jest code coverage

### DIFF
--- a/.changeset/loud-clouds-peel.md
+++ b/.changeset/loud-clouds-peel.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-javascript": patch
+---
+
+Added integration test cases to improve Jest code coverage.

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -22,10 +22,13 @@ const path = require('path');
 const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const ResBundle = require("ilib/lib/ResBundle");
 
-describe('integrationtest the localization result of webos-js app', () => {
-    const projectRoot = (process.cwd().indexOf("integrationTest")) >-1 ? ".": "./test/integrationTest";
+describe('[integration] test the localization result of webos-js app', () => {
+    const projectRoot = (process.cwd().indexOf("integrationTest")) > -1 ? "." : "./test/integrationTest";
     const defaultRSPath = path.join(process.cwd(), projectRoot, "resources");
     beforeAll(async() => {
+        if (fs.existsSync(defaultRSPath)) {
+            fs.rmSync(defaultRSPath, { recursive: true });
+        }
         const projectSettings = {
             "rootDir": projectRoot,
             "id": "sample-webos-js",
@@ -63,7 +66,7 @@ describe('integrationtest the localization result of webos-js app', () => {
                 "en-AU": "en-GB",
             }
         };
-        var project = ProjectFactory.newProject(projectSettings, appSettings);
+        const project = ProjectFactory.newProject(projectSettings, appSettings);
         project.addPath("src/sample.js");
         
         if (project) {

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -1,0 +1,152 @@
+/*
+ * JsApp.test.js - test the localization result of webos-js app.
+ *
+ * Copyright (c) 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const ProjectFactory = require("loctool/lib/ProjectFactory.js");
+const ResBundle = require("ilib/lib/ResBundle");
+
+describe('integrationtest the localization result of webos-js app', () => {
+    const projectRoot = "./test/integrationTest";
+    const defaultRSPath = path.join(process.cwd(), projectRoot, "resources");
+
+    beforeAll(async() => {
+        const projectSettings = {
+            "rootDir": projectRoot,
+            "id": "sample-webos-js",
+            "projectType": "webos-js",
+            "sourceLocale": "en-KR",
+            "pseudoLocale" : {
+                "zxx-XX": "debug"
+            },
+            "resourceDirs" : { "json": "resources" },
+            "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
+            "plugins": [ "ilib-loctool-webos-javascript" ],
+            "xliffStyle": "custom",
+            "xliffVersion": 2,
+        };
+        const appSettings = {
+            localizeOnly: true,
+            xliffsDir: "./xliffs",
+            mode: "localize",
+            nopseudo: false,
+            webos: {
+                "commonXliff": "./test/integrationTest/common"
+            },
+            locales:[
+                "en-AU",
+                "en-GB",
+                "en-US",
+                "es-CO",
+                "ko-KR",
+            ],
+            localeMap: {
+                "es-CO": "es",
+                "fr-CA": "fr"
+            },
+            localeInherit: {
+                "en-AU": "en-GB",
+            }
+        };
+        var project = ProjectFactory.newProject(projectSettings, appSettings);
+        project.addPath("src/sample.js");
+        
+        if (project) {
+            project.init(function() {
+                project.extract(function() {
+                    project.generatePseudo();
+                    project.write(function() {
+                        project.save(function() {
+                            project.close(function() {
+                            });
+                        });
+                    });
+                });
+            });
+        }
+
+    }, 50000);
+    afterAll(async () => {
+        if (fs.existsSync(defaultRSPath)) {
+            fs.rmSync(defaultRSPath, { recursive: true });
+        }
+    });
+    test("jssample_test_ko_KR", function() {
+        expect.assertions(5);
+        let rb = new ResBundle({
+            locale:"ko-KR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Hello").toString()).toBe("안녕");
+        expect(rb.getString("Thank you").toString()).toBe("고마워");
+        expect(rb.getString("Bye").toString()).toBe("잘가");
+        expect(rb.getString("Time Settings").toString()).toBe("시간 설정");
+    });
+    test("jssample_test_es_CO", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"es-CO",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Sound Out").toString()).toBe("Salida de Audio");
+    });
+    test("jssample_test_en_AU", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"en-AU",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+    });
+    test("jssample_test_en_GB", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"en-GB",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+    });
+    test("jssample_test_en_US", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"en-US",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Programme").toString()).toBe("Channel");
+    });
+    test("jssample_test_zxx", function() {
+        expect.assertions(7);
+        let rb = new ResBundle({
+            locale:"zxx",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Hello").toString()).toBe("[Ħëľľõ210]");
+        expect(rb.getString("Thank you").toString()).toBe("[Ťĥàñķ ÿõü43210]");
+        expect(rb.getString("Bye").toString()).toBe("[ßÿë10]");
+        expect(rb.getString("Time Settings").toString()).toBe("[Ťímë Šëţţíñğš6543210]");
+        expect(rb.getString("Sound Out").toString()).toBe("[Šõüñð Øüţ43210]");
+        expect(rb.getString("Programme").toString()).toBe("[Pŕõğŕàmmë43210]");
+    });
+});

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -23,9 +23,8 @@ const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const ResBundle = require("ilib/lib/ResBundle");
 
 describe('integrationtest the localization result of webos-js app', () => {
-    const projectRoot = "./test/integrationTest";
+    const projectRoot = (process.cwd().indexOf("integrationTest")) >-1 ? ".": "./test/integrationTest";
     const defaultRSPath = path.join(process.cwd(), projectRoot, "resources");
-
     beforeAll(async() => {
         const projectSettings = {
             "rootDir": projectRoot,
@@ -47,7 +46,7 @@ describe('integrationtest the localization result of webos-js app', () => {
             mode: "localize",
             nopseudo: false,
             webos: {
-                "commonXliff": "./test/integrationTest/common"
+                "commonXliff": path.join(projectRoot, "./common")
             },
             locales:[
                 "en-AU",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -25,7 +25,7 @@ const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
 describe('test the localization result (generate mode) of webos-js app', () => {
-    const projectRoot = "./test/integrationTest";
+    const projectRoot = (process.cwd().indexOf("integrationTest")) > -1 ? ".": "./test/integrationTest";
     const defaultRSPath = path.join(process.cwd(), projectRoot, "resources2");
     beforeAll(async() => {
         const projectSettings = {

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -1,0 +1,78 @@
+/*
+ * JsAppGenerate.test.js - test the localization result in generate mode of webos-js app.
+ *
+ * Copyright (c) 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require('path');
+const ResBundle = require("ilib/lib/ResBundle");
+
+const ProjectFactory = require("loctool/lib/ProjectFactory.js");
+const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
+
+describe('test the localization result (generate mode) of webos-js app', () => {
+    const projectRoot = "./test/integrationTest";
+    const defaultRSPath = path.join(process.cwd(), projectRoot, "resources2");
+    beforeAll(async() => {
+        const projectSettings = {
+            "rootDir": projectRoot,
+            "id": "sample-webos-js",
+            "projectType": "webos-js",
+            "sourceLocale": "en-KR",
+            "resourceDirs" : { "json": "resources2" },
+            "resourceFileTypes": { "json":"ilib-loctool-webos-json-resource" },
+            "plugins": [ "ilib-loctool-webos-javascript" ],
+            "xliffStyle": "custom",
+            "xliffVersion": 2,
+        };
+        const appSettings = {
+            localizeOnly: true,
+            xliffsDir: "./xliffs",
+            locales:[
+                "ko-KR"
+            ],
+            localeMap: {
+                "es-CO": "es",
+                "fr-CA": "fr"
+            },
+            localeInherit: {
+                "en-AU": "en-GB",
+                "en-JP": "en-GB",
+            }
+        };
+        const project = ProjectFactory.newProject(projectSettings, appSettings);
+        GenerateModeProcess(project);
+
+    }, 50000);
+    afterAll(async () => {
+        if (fs.existsSync(defaultRSPath)) {
+            fs.rmSync(defaultRSPath, { recursive: true });
+        }
+    });
+    test("jssample_generate_test_ko_KR", function() {
+        expect.assertions(5);
+        let rb = new ResBundle({
+            locale:"ko-KR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Hello").toString()).toBe("안녕");
+        expect(rb.getString("Thank you").toString()).toBe("고마워");
+        expect(rb.getString("Bye").toString()).toBe("잘가");
+        expect(rb.getString("TV On Screen").toString()).toBe("TV 켜짐 화면");
+    });
+});

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -24,10 +24,13 @@ const ResBundle = require("ilib/lib/ResBundle");
 const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
-describe('test the localization result (generate mode) of webos-js app', () => {
-    const projectRoot = (process.cwd().indexOf("integrationTest")) > -1 ? ".": "./test/integrationTest";
+describe('[integration] test the localization result (generate mode) of webos-js app', () => {
+    const projectRoot = (process.cwd().indexOf("integrationTest")) > -1 ? "." : "./test/integrationTest";
     const defaultRSPath = path.join(process.cwd(), projectRoot, "resources2");
     beforeAll(async() => {
+        if (fs.existsSync(defaultRSPath)) {
+            fs.rmSync(defaultRSPath, { recursive: true });
+        }
         const projectSettings = {
             "rootDir": projectRoot,
             "id": "sample-webos-js",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Time Settings</source>
+          <target>시간 설정</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -11,8 +11,12 @@
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
     },
+    "dependencies": {
+        "ilib-loctool-webos-javascript": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.2"
+    },
     "devDependencies": {
-        "loctool": "^2.28.2",
         "ilib": "^14.21.1",
         "jest": "^29.7.0"
     }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -1,0 +1,17 @@
+{
+    "private": true,
+    "name": "sample-webos-js",
+    "description": "Sample localization project",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "coverage": "pnpm test --coverage",
+        "test": "pnpm test:jest",
+        "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
+        "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
+    },
+    "devDependencies": {
+        "ilib": "^14.21.1"
+    }
+}

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -5,12 +5,6 @@
     "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
-    "scripts": {
-        "coverage": "pnpm test --coverage",
-        "test": "pnpm test:jest",
-        "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
-        "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
-    },
     "devDependencies": {
         "ilib": "^14.21.1"
     }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -11,13 +11,8 @@
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
         "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
     },
-    "dependencies": {
-        "ilib-loctool-webos-javascript": "workspace:*",
-        "ilib-loctool-webos-json": "workspace:*",
-        "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.28.2"
-    },
     "devDependencies": {
+        "loctool": "^2.28.2",
         "ilib": "^14.21.1",
         "jest": "^29.7.0"
     }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -5,7 +5,20 @@
     "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",
     "version": "1.0.0",
+    "scripts": {
+        "coverage": "pnpm test --coverage",
+        "test": "pnpm test:jest",
+        "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
+        "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-javascript": "workspace:*",
+        "ilib-loctool-webos-json": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "loctool": "^2.28.2"
+    },
     "devDependencies": {
-        "ilib": "^14.21.1"
+        "ilib": "^14.21.1",
+        "jest": "^29.7.0"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "name": "sample-webos-js",
+    "name": "integration-sample-webos-js",
     "description": "Sample localization project",
     "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
     "license": "Apache-2.0",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
@@ -1,0 +1,6 @@
+msg1.reason = $L('Hello');
+msg2.reason = $L('Thank you');
+msg3.reason = $L('Time Settings');
+msg4.reason = $L('Bye');
+msg5.reason = $L('Sound Out');
+msg6.reason = $L('Programme');

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Programme</source>
+          <target>Channel</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+  <file id="sample-webos-js_f1" original="sample-webos-js">
+    <group id="sample-webos-js_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>Hello</source>
+          <target>안녕</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Thank you</source>
+          <target>고마워</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Bye</source>
+          <target>잘가</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>TV On Screen</source>
+          <target>TV 켜짐 화면</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,12 @@ importers:
         specifier: 2.28.2
         version: 2.28.2
 
+  packages/ilib-loctool-webos-javascript/test/integrationTest:
+    devDependencies:
+      ilib:
+        specifier: ^14.21.1
+        version: 14.21.1
+
   packages/ilib-loctool-webos-json:
     dependencies:
       ilib:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,10 +158,26 @@ importers:
         version: 2.28.2
 
   packages/ilib-loctool-webos-javascript/test/integrationTest:
+    dependencies:
+      ilib-loctool-webos-javascript:
+        specifier: workspace:*
+        version: link:../..
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../../ilib-loctool-webos-json
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.2
+        version: 2.28.2
     devDependencies:
       ilib:
         specifier: ^14.21.1
         version: 14.21.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-json:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,19 +158,6 @@ importers:
         version: 2.28.2
 
   packages/ilib-loctool-webos-javascript/test/integrationTest:
-    dependencies:
-      ilib-loctool-webos-javascript:
-        specifier: workspace:*
-        version: link:../..
-      ilib-loctool-webos-json:
-        specifier: workspace:*
-        version: link:../../../ilib-loctool-webos-json
-      ilib-loctool-webos-json-resource:
-        specifier: workspace:*
-        version: link:../../../ilib-loctool-webos-json-resource
-      loctool:
-        specifier: ^2.28.2
-        version: 2.28.2
     devDependencies:
       ilib:
         specifier: ^14.21.1
@@ -178,6 +165,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@12.20.55)(node-notifier@8.0.2)
+      loctool:
+        specifier: ^2.28.2
+        version: 2.28.2
 
   packages/ilib-loctool-webos-json:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,16 @@ importers:
         version: 2.28.2
 
   packages/ilib-loctool-webos-javascript/test/integrationTest:
+    dependencies:
+      ilib-loctool-webos-javascript:
+        specifier: workspace:*
+        version: link:../..
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.28.2
+        version: 2.28.2
     devDependencies:
       ilib:
         specifier: ^14.21.1
@@ -165,9 +175,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@12.20.55)(node-notifier@8.0.2)
-      loctool:
-        specifier: ^2.28.2
-        version: 2.28.2
 
   packages/ilib-loctool-webos-json:
     dependencies:


### PR DESCRIPTION
To improve code coverage, I add the integration test files for the package.
JavaScriptFileType.js: `24.32%` --> `83.63%`
