### PR TITLE
webos-dart: Fix extraction issue for localizable strings with trailing commas

### DIFF
--- a/.changeset/pink-turkeys-shave.md
+++ b/.changeset/pink-turkeys-shave.md
@@ -1,0 +1,6 @@
+---
+"integration-sample-webos-dart": patch
+"ilib-loctool-webos-dart": patch
+---
+
+Fix extraction issue for localizable strings followed by trailing commas

--- a/.changeset/pink-turkeys-shave.md
+++ b/.changeset/pink-turkeys-shave.md
@@ -1,5 +1,4 @@
 ---
-"integration-sample-webos-dart": patch
 "ilib-loctool-webos-dart": patch
 ---
 

--- a/.changeset/three-bobcats-sparkle.md
+++ b/.changeset/three-bobcats-sparkle.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-dart
+- Fix extraction issue for localizable strings followed by trailing commas

--- a/packages/ilib-loctool-webos-dart/DartFile.js
+++ b/packages/ilib-loctool-webos-dart/DartFile.js
@@ -119,8 +119,8 @@ translate("{arg1} app cannot be deleted.", arg:{"arg1": "Settings"})
 translate("The lowest temp is {arg1}", args: <String, int>{"arg1": 15})
 translate("The lowest temperature is {arg1} and the highest temperature is {arg2}.", arg:{"arg1": 15, "arg2": 30})
 */
-var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
-var reTranslateWithKey = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(key)\s*\:\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\)/g);
+var reTranslate = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*,?\s*\)/g);
+var reTranslateWithKey = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(key)\s*\:\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*,?\s*\)/g);
 var reTranslateWithArg = new RegExp(/translate\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*args\s*\:/g);
 var reTranslatePlural = new RegExp(/translatePlural\s*\(\s*("((\\"|[^"])*)"|'((\\'|[^'])*)')\s*\,\s*(.*)\)/g);
 var reI18nComment = new RegExp("//\\s*i18n\\s*:\\s*(.*)$");

--- a/packages/ilib-loctool-webos-dart/test/DartFile.test.js
+++ b/packages/ilib-loctool-webos-dart/test/DartFile.test.js
@@ -941,7 +941,7 @@ describe("dartfile", function() {
         expect(set.size()).toBe(0);
     });
     test("DartFileTest2", function() {
-        expect.assertions(11);
+        expect.assertions(17);
 
         var d = new DartFile({
             project: p,
@@ -953,7 +953,7 @@ describe("dartfile", function() {
         d.extract();
 
         var set = d.getTranslationSet();
-        expect(set.size()).toBe(5);
+        expect(set.size()).toBe(7);
 
         var r = set.getBySource("Track");
         expect(r).toBeTruthy();
@@ -971,6 +971,16 @@ describe("dartfile", function() {
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe("first number {arg1}, second number {arg2}, and third number {arg3}");
         expect(r.getKey()).toBe("first number {arg1}, second number {arg2}, and third number {arg3}");
+
+        var r = set.getBySource("Trailing Commas");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Trailing Commas");
+        expect(r.getKey()).toBe("Trailing Commas");
+
+        var r = set.getBySource("Trailing Commas with key");
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Trailing Commas with key");
+        expect(r.getKey()).toBe("comma");
     });
     test("DartFileTest3", function() {
         expect.assertions(20);

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -111,7 +111,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["Search"]).toBe("통합 검색");
     });
     test("dartsample_test_es_CO", function() {
-        expect.assertions(4);
+        expect.assertions(5);
         filePath = path.join(resourcePath, 'es.json');
         jsonData = pluginUtils.isValidPath(filePath) ? pluginUtils.loadData(filePath) : jsonData;
 
@@ -119,6 +119,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["App List"]).toBe("Lista de Aplicaciones");
         expect(jsonData["Search"]).toBe("Buscar");
         expect(jsonData["Back button"]).toBe("Botón regresar");
+        expect(jsonData["App Rating"]).toBe("Clasificación de Aplicación");
     });
     test("dartsample_test_es_US", function() {
         expect.assertions(2);
@@ -145,11 +146,12 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["Programme"]).toBe("Programme");
     });
     test("dartsample_test_zxx", function() {
-        expect.assertions(5);
+        expect.assertions(6);
         filePath = path.join(resourcePath, 'zxx.json');
         jsonData = pluginUtils.isValidPath(filePath) ? pluginUtils.loadData(filePath) : jsonData;
 
         expect(jsonData).toBeTruthy();
+        expect(Object.keys(jsonData).length).toBe(5);
         expect(jsonData["App List"]).toBe("[Ãþþ Ľíšţ3210]");
         expect(jsonData["Back button"]).toBe("[ßàçķ büţţõñ543210]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
@@ -2,3 +2,4 @@ translate("Search");
 translate("App List");
 translate("Back button");
 translate("Programme");
+translate('App Rating', );

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-CO.xliff
@@ -20,6 +20,12 @@
           <target>Botón regresar</target>
         </segment>
       </unit>
+      <unit id="4">
+        <segment>
+          <source>App Rating</source>
+          <target>Clasificación de Aplicación</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-dart/test/testfiles/t2.dart
+++ b/packages/ilib-loctool-webos-dart/test/testfiles/t2.dart
@@ -4,3 +4,11 @@ translate("List", args: {"arg1": "music_track"});
 
 translatePlural('1#At least 1 letter|#At least {num} letters', num);
 translate('first number {arg1}, second number {arg2}, and third number {arg3}', args: <String, int>{'arg1': 15, 'arg2': 30, 'arg3': 47});
+
+translate(
+        'Trailing Commas',
+      );
+translate(
+        'Trailing Commas with key',
+        key: "comma" ,
+      );

--- a/packages/samples-loctool/webos-dart/src/msg.dart
+++ b/packages/samples-loctool/webos-dart/src/msg.dart
@@ -22,3 +22,5 @@ static String sn_home_0016(tvModel) => translate(
         'Exclusive features for {%TV_model} are all gathered here.',
         args: {'%TV_model': tvModel},
       );
+
+translate("Trailing commas", );

--- a/packages/samples-loctool/webos-dart/test/DartApp.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartApp.test.js
@@ -79,7 +79,7 @@ describe('test the localization result of webos-dart app', () => {
         expect(jsonData["Search_all"]).toBe("Recherche");
     });
     test("dartsample_test_es_CO", function() {
-        expect.assertions(10);
+        expect.assertions(11);
         filePath = path.join(resourcePath, 'es.json');
         jsonData = isValidPath(filePath) ? loadData(filePath) : jsonData;
 
@@ -93,6 +93,7 @@ describe('test the localization result of webos-dart app', () => {
         expect(jsonData["plural.demo"].one).toBe("Has pulsado el botón una vez.");
         expect(jsonData["plural.demo"].two).toBe("Has pulsado el botón dos veces.");
         expect(jsonData["plural.demo"].other).toBe("Ha pulsado el botón {num} veces.");
+        expect(jsonData["Trailing commas"]).toBe("Comas finales");
     });
     test("dartsample_test_es_ES", function() {
         expect.assertions(7);

--- a/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
@@ -32,10 +32,16 @@
           <target>Eliminar Todo</target>
         </segment>
       </unit>
-      <unit id="5">
+      <unit id="6">
         <segment>
           <source>plural.demo</source>
           <target>0#Por favor, comience a presionar el botón 'más'.|1#Has pulsado el botón una vez.|2#Has pulsado el botón dos veces.|#Ha pulsado el botón {num} veces.</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>Trailing commas</source>
+          <target>Comas finales</target>
         </segment>
       </unit>
     </group>


### PR DESCRIPTION
Fix extraction issue for localizable strings followed by trailing commas.
fyi: https://dart.dev/tools/linter-rules/require_trailing_commas