### PR TITLE
Fix the broken documentation links after each plugin is published to npm

### DIFF
--- a/.changeset/two-radios-press.md
+++ b/.changeset/two-radios-press.md
@@ -1,0 +1,15 @@
+---
+"ilib-loctool-webos-json-resource": patch
+"ilib-loctool-webos-ts-resource": patch
+"ilib-loctool-webos-javascript": patch
+"ilib-loctool-webos-common": patch
+"ilib-loctool-webos-dart": patch
+"ilib-loctool-webos-dist": patch
+"ilib-loctool-webos-json": patch
+"ilib-loctool-webos-cpp": patch
+"ilib-loctool-webos-qml": patch
+"ilib-loctool-webos-c": patch
+"ilib-lint-webos": patch
+---
+
+Fix the broken documentation links after each plugin is published to npm

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here is the list of packages. Plugins are optimized for the webOS platform.
     <td>Category</td><td>Name</td><td>Description</td>
   </tr>
   <tr>
-    <td rowspan="10">localization</td>
+    <td rowspan="11">localization</td>
     <td>ilib-loctool-webos-c</td>
     <td>C filetype handler.</td>
   </tr>
@@ -71,6 +71,10 @@ Here is the list of packages. Plugins are optimized for the webOS platform.
   <tr>
     <td>ilib-loctool-webos-ts-resource</td>
     <td><a href="https://doc.qt.io/qt-6/linguist-ts-file-format.html">TS</a> resource filetype handler.</td>
+  </tr>
+  <tr>
+    <td>ilib-loctool-webos-common</td>
+    <td>contains functions commonly used in the plugin.</td>
   </tr>
   <tr>
     <td>ilib-loctool-webos-dist</td>

--- a/packages/ilib-lint-webos/README.md
+++ b/packages/ilib-lint-webos/README.md
@@ -22,9 +22,9 @@ is written with ESM modules.
 
 Copyright (c) 2024-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-lint-webos/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-lint-webos/CHANGELOG.md) file.

--- a/packages/ilib-lint-webos/package.json
+++ b/packages/ilib-lint-webos/package.json
@@ -43,8 +43,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-lint-webos"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-lint-webos",
     "engines": {
         "node": ">=14.0.0"
     },

--- a/packages/ilib-loctool-webos-c/README.md
+++ b/packages/ilib-loctool-webos-c/README.md
@@ -9,16 +9,16 @@ resBundle_getLocStringWithKey(resBundle, "PictureMode.Standard", "Standard");
 ```
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-c](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-c) sample to see how the C file type is localized.
+The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-c](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-c) sample to see how the C file type is localized.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-c/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-c/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-c/README.md
+++ b/packages/ilib-loctool-webos-c/README.md
@@ -9,7 +9,7 @@ resBundle_getLocStringWithKey(resBundle, "PictureMode.Standard", "Standard");
 ```
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
 Please check the [webos-c](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-c) sample to see how the C file type is localized.
 
 ## License

--- a/packages/ilib-loctool-webos-c/package.json
+++ b/packages/ilib-loctool-webos-c/package.json
@@ -35,8 +35,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-c"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-c",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-common/package.json
+++ b/packages/ilib-loctool-webos-common/package.json
@@ -25,8 +25,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-common"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-common",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-cpp/README.md
+++ b/packages/ilib-loctool-webos-cpp/README.md
@@ -10,16 +10,16 @@ getLocStringWithKey("PictureMode.Standard", "Standard");
 ```
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-cpp](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-cpp) sample to see how the Cpp file type is localized.
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-cpp](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-cpp) sample to see how the Cpp file type is localized.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-cpp/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-cpp/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-cpp/package.json
+++ b/packages/ilib-loctool-webos-cpp/package.json
@@ -36,8 +36,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-cpp"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-cpp",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-dart/README.md
+++ b/packages/ilib-loctool-webos-dart/README.md
@@ -25,16 +25,15 @@ translatePlural('1#At least 1 letter|#At least {num} letters', num);
 ```
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-dart](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-dart) sample to see how the JavaScript file type is localized.
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-dart](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-dart) sample to see how the Dart file type is localized.
 
 ## License
 
 Copyright (c) 2023-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
-file for more details.
+This plugin is license under Apache2. [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dart/LICENSE) file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dart/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-dart/package.json
+++ b/packages/ilib-loctool-webos-dart/package.json
@@ -35,8 +35,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-dart"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dart",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-dist/README.md
+++ b/packages/ilib-loctool-webos-dist/README.md
@@ -25,7 +25,7 @@ Plugins are optimized for the webOS platform.
 
 Copyright (c) 2020-2025, JEDLSoft
 
-This plugin is license under Apache2. See the (https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dist/CHANGELOG.md)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dist/LICENSE)
 file for more details.
 
 ## Release Notes

--- a/packages/ilib-loctool-webos-dist/README.md
+++ b/packages/ilib-loctool-webos-dist/README.md
@@ -25,9 +25,9 @@ Plugins are optimized for the webOS platform.
 
 Copyright (c) 2020-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the (https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dist/CHANGELOG.md)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dist/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-dist/package.json
+++ b/packages/ilib-loctool-webos-dist/package.json
@@ -6,8 +6,10 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-dist"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-dist",
     "author": {
         "name": "Goun Lee",
         "email": "goun.lee@lge.com"

--- a/packages/ilib-loctool-webos-javascript/README.md
+++ b/packages/ilib-loctool-webos-javascript/README.md
@@ -16,16 +16,16 @@ $L({value: "Channel", key: "speaker_channel"});
 ```
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-js](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-js) sample to see how the JavaScript file type is localized.
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-js](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-js) sample to see how the JavaScript file type is localized.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-javascript/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-javascript/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-javascript/package.json
+++ b/packages/ilib-loctool-webos-javascript/package.json
@@ -35,8 +35,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-javascript"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-javascript",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-json-resource/README.md
+++ b/packages/ilib-loctool-webos-json-resource/README.md
@@ -13,16 +13,16 @@ This plugin is for generating JSON type resource files from JavaScript, C, and C
 }
 ```
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-js](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-js), [webos-c](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-c), [webos-cpp](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-cpp), and [webos-dart](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-dart) samples to see what JSON files look like.
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-js](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-js), [webos-c](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-c), [webos-cpp](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-cpp), and [webos-dart](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-dart) samples to see what JSON files look like.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json-resource/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json-resource/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-json-resource/package.json
+++ b/packages/ilib-loctool-webos-json-resource/package.json
@@ -37,8 +37,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-json-resource"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json-resource",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-json/README.md
+++ b/packages/ilib-loctool-webos-json/README.md
@@ -47,17 +47,17 @@ The plugin will look for the jsonMap property within the settings of your projec
       - [filename] the file name of the matching file.
 
 #### Sample
-The simple sample is provided in the [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-json](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-json) sample to see how the JSON file type is localized.
+The simple sample is provided in the [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-json](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-json) sample to see how the JSON file type is localized.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json/CHANGELOG.md) file.
 

--- a/packages/ilib-loctool-webos-json/package.json
+++ b/packages/ilib-loctool-webos-json/package.json
@@ -34,8 +34,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-json"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-json",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-qml/README.md
+++ b/packages/ilib-loctool-webos-qml/README.md
@@ -17,17 +17,17 @@ Text { text: qsTranslate("CustomContext", "hello") }
 ```
 
 #### Sample
-The simple sample is provided in [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-qml](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-qml) sample to see how the qml file type is localized.
+The simple sample is provided in [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-qml](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-qml) sample to see how the qml file type is localized.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-qml/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-qml/CHANGELOG.md) file.
 

--- a/packages/ilib-loctool-webos-qml/package.json
+++ b/packages/ilib-loctool-webos-qml/package.json
@@ -35,8 +35,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-qml"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-qml",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/ilib-loctool-webos-ts-resource/README.md
+++ b/packages/ilib-loctool-webos-ts-resource/README.md
@@ -21,16 +21,16 @@ The TS file format used by Qt Linguist. The TS file is an intermediate output fo
 ```
 
 #### Sample
-The simple sample is provided in [ilib-loctool-samples](https://github.com/iLib-js/ilib-loctool-samples) repository.
-Please check the [webos-qml](https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-qml) sample to see what TS file looks like.
+The simple sample is provided in [samples-loctool](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool).
+Please check the [webos-qml](https://github.com/iLib-js/ilib-mono-webos/tree/main/packages/samples-loctool/webos-qml) sample to see what TS file looks like.
 
 ## License
 
 Copyright (c) 2019-2025, JEDLSoft
 
-This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+This plugin is license under Apache2. See the [LICENSE](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-ts-resource/LICENSE)
 file for more details.
 
 ## Release Notes
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
+See the [CHANGELOG.md](https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-ts-resource/CHANGELOG.md) file.

--- a/packages/ilib-loctool-webos-ts-resource/package.json
+++ b/packages/ilib-loctool-webos-ts-resource/package.json
@@ -36,8 +36,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:iLib-js/ilib-mono-webos.git"
+        "url": "git@github.com:iLib-js/ilib-mono-webos.git",
+        "directory": "packages/ilib-loctool-webos-ts-resource"
     },
+    "homepage": "https://github.com/iLib-js/ilib-mono-webos/blob/main/packages/ilib-loctool-webos-ts-resource",
     "scripts": {
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",


### PR DESCRIPTION
* Fix the broken documentation links after each plugin is published to npm
* Update the references pointing to the deprecated repository.