### PR TITLE
Update the XLIFF files to use the actual webOS namespace

### DIFF
--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="2">

--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-c">
     <group id="sample-webos-js_g1" name="c">
       <unit id="1">

--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-cpp">
     <group id="sample-webos-js_g1" name="cpp">
       <unit id="1">

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-ES.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-cpp">
     <group id="sample-webos-js_g1" name="cpp">
       <unit id="1">

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1">

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1">

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1">

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1">

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/en-GB.xliff
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-qml_f1" original="sample-webos-qml">
     <group id="sample-webos-qml_g1" name="x-qml">
       <unit id="1">

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/en-US.xliff
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-qml_f1" original="sample-webos-qml">
     <group id="sample-webos-qml_g1" name="x-qml">
       <unit id="1">

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-qml_f1" original="sample-webos-qml">
     <group id="sample-webos-qml_g1" name="x-qml">
       <unit id="1">

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-qml_f1" original="sample-webos-qml">
     <group id="sample-webos-qml_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-lint/sample-A/af-ZA.xliff
+++ b/packages/samples-lint/sample-A/af-ZA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="af-ZA">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="af-ZA" version="2.0">
  <file id="sample-A_f1" original="sample-A">
   <group id="sample-A_g1" name="javascript">
    <unit id="sample-A_1">

--- a/packages/samples-lint/sample-A/de-DE.xliff
+++ b/packages/samples-lint/sample-A/de-DE.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="de-DE">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">
  <file id="sample-A_f1" original="sample-A">
   <group id="sample-A_g1" name="javascript">
    <unit id="sample-A_1">

--- a/packages/samples-lint/sample-B/am-ET.xliff
+++ b/packages/samples-lint/sample-B/am-ET.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="am-ET">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="am-ET" version="2.0">
  <file id="sample-B_f1" original="sample-B">
   <group id="sample-B_g1" name="javascript">
    <unit id="sample-B_1">

--- a/packages/samples-lint/sample-B/ja-JP.xliff
+++ b/packages/samples-lint/sample-B/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ja-JP">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
  <file id="sample-B_f1" original="sample-B">
   <group id="sample-B_g1" name="javascript">
    <unit id="sample-B_1">

--- a/packages/samples-lint/sample-B/ko-KR.xliff
+++ b/packages/samples-lint/sample-B/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ko-KR">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
  <file id="sample-B_f1" original="sample-B">
   <group id="sample-B_g1" name="javascript">
    <unit id="sample-B_1">

--- a/packages/samples-lint/sample-B/zh-Hans-CN.xliff
+++ b/packages/samples-lint/sample-B/zh-Hans-CN.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="zh-Hans-CN" version="2.0">
  <file id="sample-B_f1" original="sample-B">
   <group id="sample-B_g1" name="javascript">
    <unit id="sample-B_1">

--- a/packages/samples-loctool/webos-c/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-c/common/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-c/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-c/common/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-c/common/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-c/common/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-c/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-c/common/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-c/common/ja-JP.xliff
+++ b/packages/samples-loctool/webos-c/common/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-c/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-c/common/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-c/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-c">
     <group id="sample-webos-js_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-c">
     <group id="sample-webos-js_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-c/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-c/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-c_f1" original="sample-webos-c">
     <group id="sample-webos-c_g1" name="c">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-cpp/common/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-cpp/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-cpp/common/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-cpp/common/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-cpp/common/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-cpp/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-cpp/common/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-cpp/common/ja-JP.xliff
+++ b/packages/samples-loctool/webos-cpp/common/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-cpp/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-cpp/common/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-cpp/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-cpp">
     <group id="sample-webos-js_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-cpp">
     <group id="sample-webos-js_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-cpp/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-cpp/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-cpp_f1" original="sample-webos-cpp">
     <group id="sample-webos-cpp_g1" name="cpp">
       <unit id="1">

--- a/packages/samples-loctool/webos-dart/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-dart/common/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-dart/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-dart/common/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-dart/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-json_g1" name="x-dart">
       <unit id="1">

--- a/packages/samples-loctool/webos-dart/xliffs/sl-SI.xliff
+++ b/packages/samples-loctool/webos-dart/xliffs/sl-SI.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="sl-SI" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="sl-SI" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
       <unit id="1" name="Search_all">

--- a/packages/samples-loctool/webos-js/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-js/common/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-js/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-js/common/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-js/common/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js/common/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-js/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js/common/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-js/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/common/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-js/xliffs/as-IN.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/as-IN.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="as-IN" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/de-DE.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/de-DE.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ja-JP.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ja-JP" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/ko-TW.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-TW.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-TW" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-TW" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-js/xliffs/ko-US.xliff
+++ b/packages/samples-loctool/webos-js/xliffs/ko-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-US" version="2.0">
   <file id="sample-webos-js_f1" original="sample-webos-js">
     <group id="sample-webos-js_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/common/it-IT.xliff
+++ b/packages/samples-loctool/webos-json/common/it-IT.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="it-IT" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-json/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/common/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-json/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/kn-IN.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="kn-IN">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="kn-IN" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hans-CN.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hans-CN.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hans-CN" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="zh-Hans-CN" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hant-HK.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hant-HK.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-HK" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="zh-Hant-HK" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-json/xliffs/zh-Hant-TW.xliff
+++ b/packages/samples-loctool/webos-json/xliffs/zh-Hant-TW.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="zh-Hant-TW" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="zh-Hant-TW" version="2.0">
   <file id="sample-webos-json_f1" original="sample-webos-json">
     <group id="sample-webos-json_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-qml/common/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-qml/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-qml/common/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-qml/common/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-qml/common/fr-CA.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-CA" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-qml/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-qml/common/fr-FR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-qml/common/it-IT.xliff
+++ b/packages/samples-loctool/webos-qml/common/it-IT.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="it-IT" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-qml/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-qml/common/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="common_f1" original="common">
     <group id="common_g1" name="javascript">
       <unit id="common_1">

--- a/packages/samples-loctool/webos-qml/xliffs/as-IN.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/as-IN.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="as-IN" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="as-IN" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/en-GB.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-GB" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/en-US.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="en-US" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/es-CO.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-CO" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/es-ES.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="es-ES" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/it-IT.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/it-IT.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="it-IT" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="it-IT" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">

--- a/packages/samples-loctool/webos-qml/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-qml/xliffs/ko-KR.xliff
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="music_f1" original="music">
     <group id="music_g1" name="x-qml">
       <unit id="1">


### PR DESCRIPTION
### Description
Update the XLIFF files to use the actual webOS namespace

**AS-IS**
```
<xliff version="2.0" srcLang="en-KR" trgLang="ko-KR" xmlns:l="http://ilib-js.com/loctool">
```

**TO-BE**
```
<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0"  srcLang="en-KR" trgLang="ko-KR" version="2.0">
```