### PR TITLE
Update the loctool version in peerDepenencies.

### DIFF
--- a/packages/ilib-loctool-webos-c/package.json
+++ b/packages/ilib-loctool-webos-c/package.json
@@ -55,7 +55,7 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-common/package.json
+++ b/packages/ilib-loctool-webos-common/package.json
@@ -36,7 +36,7 @@
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-cpp/package.json
+++ b/packages/ilib-loctool-webos-cpp/package.json
@@ -56,7 +56,7 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-dart/package.json
+++ b/packages/ilib-loctool-webos-dart/package.json
@@ -57,7 +57,7 @@
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-javascript/package.json
+++ b/packages/ilib-loctool-webos-javascript/package.json
@@ -55,7 +55,7 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-json-resource/package.json
+++ b/packages/ilib-loctool-webos-json-resource/package.json
@@ -56,7 +56,7 @@
         "ilib": "^14.21.1"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-json/package.json
+++ b/packages/ilib-loctool-webos-json/package.json
@@ -54,7 +54,7 @@
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-qml/package.json
+++ b/packages/ilib-loctool-webos-qml/package.json
@@ -55,7 +55,7 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",

--- a/packages/ilib-loctool-webos-ts-resource/package.json
+++ b/packages/ilib-loctool-webos-ts-resource/package.json
@@ -57,7 +57,7 @@
         "xml-js": "^1.6.11"
     },
     "peerDependencies": {
-        "loctool": "2.28.2"
+        "loctool": "2.29.3"
     },
     "devDependencies": {
         "jest": "^30.0.0",


### PR DESCRIPTION
Update the loctool version in peerDepenencies.
It should have updated it together in the [PR#46](https://github.com/iLib-js/ilib-mono-webos/pull/46l)
