### PR TITLE
Fix the missing changelog for the dependency updates

### DIFF
--- a/.changeset/lazy-actors-fetch.md
+++ b/.changeset/lazy-actors-fetch.md
@@ -1,0 +1,8 @@
+---
+"ilib-loctool-webos-dist": patch
+"ilib-loctool-webos-json": patch
+"ilib-loctool-webos-json-resource": patch
+"ilib-loctool-webos-ts-resource": patch
+---
+
+Updated dependencies. (loctool: 2.31.1)


### PR DESCRIPTION
Fix the missing changelog for the dependency updates
Updated dependencies. (loctool: 2.31.1)
