### PR TITLE
xliff-webos: Create a new `ilib-xliff-webos` for use with loctool and lint

### DIFF
--- a/.changeset/yellow-adults-behave.md
+++ b/.changeset/yellow-adults-behave.md
@@ -1,0 +1,5 @@
+---
+"ilib-xliff-webos": major
+---
+
+Initial version

--- a/packages/ilib-xliff-webos/LICENSE
+++ b/packages/ilib-xliff-webos/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ilib-xliff-webos/package.json
+++ b/packages/ilib-xliff-webos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-xliff-webos",
-    "version": "1.0.0",
+    "version": "0.0.0",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/packages/ilib-xliff-webos/package.json
+++ b/packages/ilib-xliff-webos/package.json
@@ -35,7 +35,7 @@
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:watch": "pnpm test:jest --watch",
-        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
+        "debug": "node --experimental-vm-modules --inspect-brk node_modules/jest/bin/jest.js -i",
         "clean": "git clean -f -d *"
     },
     "repository": {

--- a/packages/ilib-xliff-webos/package.json
+++ b/packages/ilib-xliff-webos/package.json
@@ -1,0 +1,50 @@
+{
+    "name": "ilib-xliff-webos",
+    "version": "1.0.0",
+    "main": "./lib/index.js",
+    "module": "./src/index.js",
+    "exports": {
+        ".": {
+            "import": "./src/index.js",
+            "require": "./lib/index.js"
+        }
+    },
+    "description": "Library of code to parse and generate webOS XLIFF files.",
+    "license": "Apache-2.0",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "xliff"
+    ],
+    "author": {
+        "name": "Goun Lee",
+        "email": "goun.lee@lge.com"
+    },
+    "contributors": [
+        {
+            "name": "Goun Lee",
+            "email": "goun.lee@lge.com"
+        }
+    ],
+    "scripts": {
+        "coverage": "pnpm test --coverage",
+        "test": "pnpm test:jest",
+        "test:jest": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/jest/bin/jest.js",
+        "test:watch": "pnpm test:jest --watch",
+        "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i",
+        "clean": "git clean -f -d *"
+    },
+    "repository": {
+        "type": "git",
+        "url": "\"https://github.com/iLib-js/ilib-mono-webos.git\""
+    },
+    "dependencies": {
+        "ilib-common": "^1.1.2",
+        "ilib-xml-js": "^1.7.0",
+        "jest": "^30.0.5"
+    }
+}

--- a/packages/ilib-xliff-webos/src/TranslationUnit.js
+++ b/packages/ilib-xliff-webos/src/TranslationUnit.js
@@ -1,0 +1,97 @@
+/*
+ * TranslationUnit.js - model a translation unit
+ *
+ * Copyright (c) 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class A class that represents an translation unit in an
+ * xliff file.
+ */
+class TranslationUnit {
+    /**
+     * Construct a new translation unit The options may be undefined, which represents
+     * a new, clean TranslationUnit instance.
+     *
+     * If the required properties are not given, the constructor throws an exception.<p>
+     *
+     * For newly extracted strings, there is no target text yet. There must be a target
+     * locale for the translators to use when creating new target text, however. This
+     * means that there may be multiple translation units in a file with the same
+     * source locale and no target text, but different target locales.
+     *
+     * @constructor
+     * @param {Object} options options to initialize the unit, or undefined for a new empty unit
+     * @param {string} options.source source text for this unit
+     * @param {string} options.sourceLocale the source locale spec for this unit
+     * @param {string} options.key the unique resource key for this translation unit
+     * @param {string} options.file path to the original source code file that contains the
+     * source text of this translation unit
+     * @param {string} [options.target] target text for this unit
+     * @param {string} [options.targetLocale] the target locale spec for this unit
+     * @param {string} [options.project] the project that this string/unit is part of
+     * @param {string} [options.resType] type of this resource (string, array, plural)
+     * @param {string} [options.state] the state of the current unit
+     * @param {string} [options.comment] the translator's comment for this unit
+     * @param {string} [options.datatype] the source of the data of this unit
+     * @param {string} [options.flavor] the flavor that this string comes from
+     * @param {boolean} [options.translate] flag that tells whether to translate this unit
+     * @param {Object} [options.location] the line and character location of the start of this
+     * translation unit in the xml representation of the file
+     * @param {Object} [options.extended] extended properties for this unit. This is an object that
+     * can contain any additional properties that are not explicitly defined in
+     * this class. This is useful for storing additional metadata about the
+     * translation unit that may be specific to a particular application or
+     * use case.
+     * @param {string} [options.resfile] the resource file that this unit came from. The file
+     * property is the path to the file in the source code where the
+     * resource was originally extracted from before it was put in the resource
+     * file, and this property is the path to the resource file that contains this
+     * translation unit. This is always the same as the xliff file that is currently
+     * being processed. The resfile property is only set when the xliff file is
+     * created from parsing a resource file. It is undefined when the xliff file is
+     * created from parsing a string or when the xliff is new and being created
+     * from scratch.
+     */
+    constructor(options) {
+        if (options) {
+            const everything = ["source", "sourceLocale", "key", "file", "project"].every((p) => {
+                return typeof(options[p]) !== "undefined";
+            });
+
+            if (!everything) {
+                const missing = ["source", "sourceLocale", "key", "file", "project"].filter((p) => {
+                    return typeof(options[p]) === "undefined";
+                });
+                throw new Error(`Missing required parameters in the TranslationUnit constructor: ${missing.join(", ")}`);
+            }
+
+            for (let p in options) {
+                this[p] = options[p];
+            }
+        }
+    }
+
+    /**
+     * Clone the current unit and return the clone.
+     * @returns {TranslationUnit} a clone of the current unit.
+     */
+    clone() {
+        return new TranslationUnit(this);
+    }
+}
+
+export default TranslationUnit;

--- a/packages/ilib-xliff-webos/src/index.js
+++ b/packages/ilib-xliff-webos/src/index.js
@@ -1,0 +1,26 @@
+/*
+ * index.js - export everything from all of the files
+ *
+ * Copyright (c) 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import webOSXliff from './webOSXliff.js';
+import TranslationUnit from './TranslationUnit.js';
+
+export {
+    webOSXliff,
+    TranslationUnit
+};

--- a/packages/ilib-xliff-webos/src/package.json
+++ b/packages/ilib-xliff-webos/src/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/packages/ilib-xliff-webos/src/package.json
+++ b/packages/ilib-xliff-webos/src/package.json
@@ -1,4 +1,5 @@
 {
-    "name": "ilib-xliff:src",
+    "private": true,
+    "name": "ilib-xliff-src",
     "type": "module"
 }

--- a/packages/ilib-xliff-webos/src/package.json
+++ b/packages/ilib-xliff-webos/src/package.json
@@ -1,1 +1,4 @@
-{"type": "module"}
+{
+    "name": "ilib-xliff:src",
+    "type": "module"
+}

--- a/packages/ilib-xliff-webos/src/webOSXliff.js
+++ b/packages/ilib-xliff-webos/src/webOSXliff.js
@@ -2,7 +2,7 @@
 /*
  * webOSXliff.js - model an xliff file for the webOS
  *
- * Copyright © 2025, JEDLSoft
+ * Copyright (c) 2025, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 import xmljs from 'ilib-xml-js';
 import { JSUtils } from 'ilib-common';
+import TranslationUnit from './TranslationUnit.js';
 
 /**
  * Return a string that can be used as an HTML attribute value.
@@ -228,7 +229,7 @@ class webOSXliff {
         const targetLocale = this.tu[0].targetLocale;
         let hasMetadata = false;
 
-        const units = units
+        const units = this.tu
             .filter(unit => unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale))
             .sort((a, b) => {
                 if (a.project < b.project) return -1;
@@ -387,7 +388,7 @@ class webOSXliff {
             position: true
         });
 
-        this.parse(json.xliff);
+        this.parse(json.xliff, resfile);
         return this.tu;
     }
 
@@ -474,7 +475,8 @@ class webOSXliff {
                                         state: state,
                                         datatype: datatype,
                                         flavor: fileSettings.flavor,
-                                        metadata: tu['mda:metadata'] || undefined
+                                        metadata: tu['mda:metadata'] || undefined,
+                                        resfile
                                     };
 
                                     let unit = new TranslationUnit(commonProperties);
@@ -490,6 +492,7 @@ class webOSXliff {
                 }
             }
         }
+        return this.tu;
     }
 
     /**

--- a/packages/ilib-xliff-webos/src/webOSXliff.js
+++ b/packages/ilib-xliff-webos/src/webOSXliff.js
@@ -1,0 +1,518 @@
+
+/*
+ * webOSXliff.js - model an xliff file for the webOS
+ *
+ * Copyright © 2025, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import xmljs from 'ilib-xml-js';
+import { JSUtils } from 'ilib-common';
+
+/**
+ * Return a string that can be used as an HTML attribute value.
+ * @private
+ * @param {string} str the string to escape
+ * @returns {string} the escaped string
+ */
+function escapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/&/g, "&amp;").
+        replace(/"/g, "&quot;").
+        replace(/'/g, "&apos;").
+        replace(/</g, "&lt;");
+}
+
+/**
+ * Return the original string based on the one that was used as an attribute value.
+ * @private
+ * @param {string} str the string to unescape
+ * @returns {string} the unescaped string
+ */
+function unescapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/&lt;/g, '<').
+        replace(/&quot;/g, '"').
+        replace(/&apos;/g, "'").
+        replace(/&amp;/g, "&");
+}
+
+/**
+ * @private
+ */
+function makeArray(arrayOrObject) {
+    return Array.isArray(arrayOrObject) ? arrayOrObject : [ arrayOrObject ];
+}
+
+/**
+ * @private
+ */
+function versionString(num) {
+    const parts = ("" + num).split(".");
+    const integral = parts[0].toString();
+    const fraction = parts[1] || "0";
+    return integral + '.' + fraction;
+}
+
+
+/**
+ * @class A class that represents an xliff file for webOS. Xliff stands for Xml
+ * Localization Interchange File Format.
+ */
+class webOSXliff {
+    version = 2.0;
+    sourceLocale = "en-KR";
+    // place to store the translation units
+    tu = [];
+    tuhash = {};
+    lines = 0;
+
+    /**
+     * Construct a new Xliff instance. The options may be undefined,
+     * which represents a new, clean Xliff instance. The options object may also
+     * be an object with any of the following properties:
+     *
+     * <ul>
+     * <li><i>tool-id</i> - the id of the tool that saved this xliff file
+     * <li><i>tool-name</i> - the full name of the tool that saved this xliff file
+     * <li><i>tool-version</i> - the version of the tool that save this xliff file
+     * <li><i>tool-company</i> - the name of the company that made this tool
+     * <li><i>copyright</i> - a copyright notice that you would like included into the xliff file
+     * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
+     * <li><i>allowDups</i> - allow duplicate resources in the xliff. By default, dups are
+     * filtered out. This option allows you to have trans-units that represent instances of the
+     * same resource in the file with different metadata. For example, two instances of a
+     * resource may have different comments which may both be useful to translators or
+     * two instances of the same resource may have been extracted from different source files.
+     * <li><i>version</i> - The version of xliff that will be produced by this instance.
+     * </ul>
+     *
+     * @constructor
+     * @param {Array.<Object>|undefined} options options to
+     * initialize the file, or undefined for a new empty file
+     */
+    constructor(options) {
+        if (options) {
+            this.path = options.path;
+            this.sourceLocale = options.sourceLocale;
+            this.project = options.project;
+            this.allowDups = options.allowDups;
+            this.style =  options.style || "standard";
+            if (typeof(options.version) !== 'undefined') {
+                this.version = Number.parseFloat(options.version);
+            }
+        }
+    }
+
+    /**
+     * @private
+     * @param project
+     * @param context
+     * @param sourceLocale
+     * @param targetLocale
+     * @param source
+     * @param key
+     * @param type
+     * @param path
+     * @returns {String} the hash of the above parameters
+     */
+    _hashKey(project, context, sourceLocale, targetLocale, source, key, type, path, ordinal, quantity, flavor) {
+        const hashkey = [source, key, type || "string", sourceLocale || this.sourceLocale, targetLocale || "", context || "", project, path || "", ordinal || "", quantity || "", flavor || ""].join("_");
+        return hashkey;
+    }
+
+    /**
+     * Get the translation units in this xliff.
+     *
+     * @returns {Array.<Object>} the translation units in this xliff
+     */
+    getTranslationUnits() {
+        return this.tu;
+    }
+
+    /**
+     * Add this translation unit to this xliff.
+     *
+     * @param {TranslationUnit} unit the translation unit to add to this xliff
+     */
+    addTranslationUnit = function(unit) {
+        let oldUnit;
+        
+        const hashKeySource = this._hashKey(unit.project, unit.context, unit.sourceLocale, "", unit.source, unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor, unit.datatype),
+        hashKeyTarget = this._hashKey(unit.project, unit.context, unit.sourceLocale, unit.targetLocale, unit.source, unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor, unit.datatype);
+
+        if (unit.targetLocale) {
+            oldUnit = this.tuhash[hashKeySource];
+            if (oldUnit) {
+                // console.log("Replacing old source-only unit in favour of this joint source/target unit");
+                this.tuhash[hashKeySource] = undefined;
+                JSUtils.shallowCopy(unit, oldUnit);
+                this.tuhash[hashKeyTarget] = oldUnit;
+                return;
+            }
+        }
+
+        oldUnit = this.tuhash[hashKeyTarget];
+        if (oldUnit && !this.allowDups) {
+            // update the old unit with this new info
+            JSUtils.shallowCopy(unit, oldUnit);
+        } else {
+            if (this.version >= 2 && this.tu.length) {
+                if (this.tu[0].targetLocale !== unit.targetLocale) {
+                    throw "Mismatched target locale";
+                }
+            }
+
+            this.tu.push(unit);
+            this.tuhash[hashKeyTarget] = unit;
+        }
+
+    }
+
+    /**
+     * Add translation units to this xliff.
+     *
+     * @param {Array.<Object>} files the translation units to add to this xliff
+     */
+    addTranslationUnits(units) {
+        units.forEach((unit) => {
+            this.addTranslationUnit(unit);
+        });
+    }
+
+    /**
+     * Return the number of translation units in this xliff file.
+     *
+     * @return {number} the number of translation units in this xliff file
+     */
+    size() {
+        return this.tu.length;
+    }
+
+    /**
+     * Serialize this xliff instance to a string that contains
+     * the xliff format xml text.
+     *
+     * @param {boolean} untranslated if true, add the untranslated resources
+     * to the xliff file without target tags. Otherwiwe, untranslated
+     * resources are skipped.
+     * @return {String} the current instance encoded as an xliff format
+     * xml text
+     */
+    serialize(untranslated) {
+        const xml = this.toStringData();
+        return xml
+    }
+
+    /**
+     * Serialize this xliff instance as an customized xliff 2.0 format string.
+     * @return {String} the current instance encoded as an customized xliff 2.0
+     * format string
+     */
+    toStringData() {
+        const sourceLocale = this.tu[0].sourceLocale;
+        const targetLocale = this.tu[0].targetLocale;
+        let hasMetadata = false;
+
+        const units = units
+            .filter(unit => unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale))
+            .sort((a, b) => {
+                if (a.project < b.project) return -1;
+                if (a.project > b.project) return 1;
+                return 0;
+            });
+
+        let json = {
+            xliff: {
+                _attributes: {
+                    "xmlns": "urn:oasis:names:tc:xliff:document:2.0",
+                }
+            }
+        };
+        // now finally add each of the units to the json
+        let files = {};
+        let index = 1;
+        let fileIndex = 1;
+        let datatype;
+        let groupIndex = 1;
+
+        for (let i = 0; i < units.length; i++) {
+            let tu = units[i];
+            if (!tu) {
+                console.log("undefined?");
+            }
+            let hashKey = tu.project;
+            let file = files[hashKey];
+            if (!file) {
+                files[hashKey] = file = {
+                    _attributes: {
+                        "id": tu.project + "_f" + fileIndex++,
+                        "original": tu.project
+                    },
+                    group : [
+                        {
+                            _attributes: {
+                                "id": tu.project + "_g" + groupIndex++,
+                                "name": tu.datatype || "javascript"
+                        },
+                        unit: []
+                    }
+                ]
+            };
+        }
+
+        let tujson = {
+            _attributes: {
+                "id": (tu.id || index++),
+                 "name": (tu.source !== tu.key) ? escapeAttr(tu.key) : undefined,
+            }
+        };
+
+        if (tu.metadata) {
+            tujson["mda:metadata"] = tu.metadata
+            hasMetadata = true;
+        }
+
+        if (tu.comment) {
+            tujson.notes = {
+                "note": [
+                    {
+                        "_text": tu.comment
+                    }
+                ]
+            };
+        }
+
+        tujson.segment = [
+            {
+                "source": {
+                    "_text": tu.source
+                }
+            }
+        ];
+
+        if (tu.id && tu.id > index) {
+            index = tu.id + 1;
+        }
+
+        if (tu.target) {
+            tujson.segment[0].target = {
+                _attributes: {
+                    state: tu.state,
+                },
+                "_text": tu.target
+            };
+        }
+
+        datatype = tu.datatype || "javascript";
+        if (!files[hashKey].group) {
+            files[hashKey].group = [];
+        }
+
+        let groupSet = {
+            _attributes: {},
+            unit: []
+        }
+
+        let existGroup = files[hashKey].group.filter(function(item) {
+            if (item._attributes.name === datatype) {
+                return item;
+            }
+        })
+
+        if (existGroup.length > 0) {
+            existGroup[0].unit.push(tujson);
+        } else {
+            groupSet._attributes.id = tu.project+ "_g" + groupIndex++;
+            groupSet._attributes.name = datatype;
+            files[hashKey].group.push(groupSet);
+            groupSet.unit.push(tujson);
+        }
+        }
+
+        // sort the file tags so that they come out in the same order each time
+        if (!json.xliff.file) {
+            json.xliff.file = [];
+        }
+        Object.keys(files).sort().forEach(function(fileHashKey) {
+            json.xliff.file.push(files[fileHashKey]);
+        });
+
+        if (hasMetadata) {
+            json.xliff._attributes["xmlns:mda"] = "urn:oasis:names:tc:xliff:metadata:2.0";
+        }
+        json.xliff._attributes.srcLang = sourceLocale;
+        if (targetLocale) {
+            json.xliff._attributes.trgLang = targetLocale;
+        }
+        json.xliff._attributes.version = versionString(this.version);
+
+        let xml = '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+            compact: true,
+            spaces: 2
+        });
+
+        return xml;
+    }
+
+    /**
+     * Deserialize the given string as an xml file in xliff format
+     * into this xliff instance. If there are any existing translation
+     * units already in this instance, they will be removed first.
+     *
+     * @param {String} xml the xliff format text to parse
+     * @param {string | undefined} resfile the path to the xliff file,
+     * or undefined if this xml file is being parsed from a string
+     * instead of a file
+     */
+    deserialize(xml, resfile) {
+        const json = xmljs.xml2js(xml, {
+            trim: false,
+            nativeTypeAttribute: true,
+            compact: true,
+            position: true
+        });
+
+        this.parse(json.xliff);
+        return this.tu;
+    }
+
+    /**
+     * Parse webOS xliff files
+     *
+     * @private
+     * @param {Element} xliff
+     * @param {string|undefined} resfile the path to the xliff file
+     * that contains the translation units, or undefined if this xliff
+     * is being parsed from a string
+     */
+    parse(xliff, resfile) {
+        const sourceLocale = xliff._attributes["srcLang"] || this.project.sourceLocale;
+        const targetLocale = xliff._attributes["trgLang"];
+
+        if (xliff.file) {
+            const files = makeArray(xliff.file);
+            for (let i = 0; i < files.length; i++) {
+                let fileSettings = {};
+                let file = files[i];
+                let groups = [];
+                fileSettings = {
+                    pathName: file._attributes["original"],
+                    locale: sourceLocale,
+                    project: file._attributes["l:project"] || file._attributes["original"],
+                    targetLocale: targetLocale,
+                    flavor: file._attributes["l:flavor"]
+                };
+                groups = (typeof (file["group"]) != 'undefined') ? file.group : file;
+                groups = makeArray(groups);
+
+                for (let j=0; j < groups.length; j++) {
+                    if (groups[j].unit) {
+                        let transUnits = makeArray(groups[j].unit);
+                        let groupName = groups[j]["_attributes"].name;
+                        transUnits.forEach((tu) => {
+                            let comment, state;
+                            let datatype = tu._attributes["l:datatype"] || groupName;
+                            let source = "", target = "";
+                            if (tu.notes && tu.notes.note) {
+                                comment = Array.isArray(tu.notes.note) ?
+                                    tu.notes.note[0]["_text"] :
+                                    tu.notes.note["_text"];
+                            }
+                            let resname = tu._attributes.name;
+                            let restype = "string";
+                            if (tu._attributes.type && tu._attributes.type.startsWith("res:")) {
+                                restype = tu._attributes.type.substring(4);
+                            }
+                            if (tu.segment) {
+                                let segments = makeArray(tu.segment);
+                                for (let j = 0; j < segments.length; j++) {
+                                    let segment = segments[j];
+                                    if (segment.source["_text"]) {
+                                        source += segment.source["_text"];
+                                        if (segment.target) {
+                                            target += segment.target["_text"];
+                                            if (segment.target.state) {
+                                                state = segment.target._attributes.state;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if (!resname) {
+                                resname = source;
+                            }
+
+                            if (source.trim()) {
+                                try {
+                                    let commonProperties = {
+                                        file: fileSettings.pathName,
+                                        sourceLocale: fileSettings.locale,
+                                        project: fileSettings.project,
+                                        id: tu._attributes.id,
+                                        key: unescapeAttr(resname),
+                                        source: source,
+                                        context: tu._attributes["l:context"],
+                                        comment: comment,
+                                        targetLocale: targetLocale,
+                                        target: target,
+                                        resType: restype,
+                                        state: state,
+                                        datatype: datatype,
+                                        flavor: fileSettings.flavor,
+                                        metadata: tu['mda:metadata'] || undefined
+                                    };
+
+                                    let unit = new TranslationUnit(commonProperties);
+                                    this.tu.push(unit);
+                                } catch (e) {
+                                    console.log("Skipping invalid translation unit found in xliff file.\n" + e);
+                                }
+                            } else {
+                                //console.log("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu.resname);
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the version of this xliff file. If you deserialize a string into this
+     * instance of Xliff, the version will be reset to whatever is found inside of
+     * the xliff file.
+     *
+     * @returns {String} the version of this xliff
+     */
+    getVersion() {
+        return this.version || "2.0";
+    }
+
+    /**
+     * Clear the current xliff file of all translation units and start from scratch. All
+     * the settings from the constructor are still kept. Only the translation units are
+     * removed.
+     */
+    clear() {
+        this.tu = [];
+        this.tuhash = {};
+    }
+    
+}
+
+export default webOSXliff;

--- a/packages/ilib-xliff-webos/test/package.json
+++ b/packages/ilib-xliff-webos/test/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/packages/ilib-xliff-webos/test/package.json
+++ b/packages/ilib-xliff-webos/test/package.json
@@ -1,1 +1,4 @@
-{"type": "module"}
+{
+    "name": "ilib-xliff:test",
+    "type": "module"
+}

--- a/packages/ilib-xliff-webos/test/package.json
+++ b/packages/ilib-xliff-webos/test/package.json
@@ -1,4 +1,5 @@
 {
-    "name": "ilib-xliff:test",
+    "private": true,
+    "name": "ilib-xliff-test",
     "type": "module"
 }

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -1,0 +1,290 @@
+/*
+ * webOSXliff.test.js - test the webOS xliff object.
+ *
+ * Copyright (c) 2025 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import webOSXliff from "../src/webOSXliff.js";
+import TranslationUnit from "../src/TranslationUnit.js";
+
+describe("webOSXliff", () => {
+    test("should create webOSXliffinstance", () => {
+        expect.assertions(1);
+        var x = new webOSXliff();
+        expect(x).toBeTruthy();
+    });
+    test("should create empty webOSXliff instance", () => {
+        expect.assertions(2);
+        var x = new webOSXliff({version: "2.0"});
+        expect(x).toBeTruthy();
+        expect(x.size()).toBe(0);
+    });
+    test("should handle numeric version 2.0", () => {
+        expect.assertions(2);
+        var x = new webOSXliff({version: 2.0});
+        expect(x).toBeTruthy();
+        expect(x.size()).toBe(0);
+    });
+    test("should create webOSXliff instance with configuration", () => {
+        expect.assertions(5);
+        var x = new webOSXliff({
+            version: "2.0",
+            style: "webOS",
+            sourceLocale: "en-KR",
+            path: "a/b/ko-KR.xliff"
+        });
+        expect(x).toBeTruthy();
+        expect(x.getVersion()).toBe(2.0);
+        expect(x["style"]).toBe("webOS");
+        expect(x.sourceLocale).toBe("en-KR");
+        expect(x.path).toBe("a/b/ko-KR.xliff");
+    });
+    test("should add translation unit to webOS  xliff", () => {
+        expect.assertions(11);
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        const tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("foo/bar/asdf.js");
+        expect(tulist[0].state).toBe("new");
+        expect(tulist[0].comment).toBe("This is a comment");
+        expect(tulist[0].project).toBe("webapp");
+        expect(tulist[0].datatype).toBe("javascript");
+    });
+    test("should add multiple translation units to webOS  xliff", () => {
+        expect.assertions(19);
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        tu = new TranslationUnit({
+            source: "foobar",
+            sourceLocale: "en-KR",
+            key: "asdf",
+            file: "x.js",
+            project: "webapp",
+            resType: "array",
+            state: "translated",
+            comment: "No comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        const tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(2);
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("foo/bar/asdf.js");
+        expect(tulist[0].state).toBe("new"); 
+        expect(tulist[0].comment).toBe("This is a comment");
+        expect(tulist[0].project).toBe("webapp");
+        expect(tulist[0].datatype).toBe("javascript");
+
+        expect(tulist[1].source).toBe("foobar");
+        expect(tulist[1].sourceLocale).toBe("en-KR");
+        expect(tulist[1].key).toBe("asdf");
+        expect(tulist[1].file).toBe("x.js");
+        expect(tulist[1].state).toBe("translated");
+        expect(tulist[1].comment).toBe("No comment");
+        expect(tulist[1].project).toBe("webapp");
+        expect(tulist[1].datatype).toBe("javascript");
+    });
+    test("should handle adding same translation unit twice in webOS  xliff", () => {
+        expect.assertions(11);
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+        x.addTranslationUnit(tu); // second time should not add anything
+
+        const tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("foo/bar/asdf.js");
+        expect(tulist[0].state).toBe("new");
+        expect(tulist[0].comment).toBe("This is a comment");
+        expect(tulist[0].project).toBe("webapp");
+        expect(tulist[0].datatype).toBe("javascript");
+    });
+    test('should add translation unit with same TU twice without duplication in webOS  xliff', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+        x.addTranslationUnit(tu); // second time should not add anything
+
+        const tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("foo/bar/asdf.js");
+        expect(tulist[0].state).toBe("new");
+        expect(tulist[0].comment).toBe("This is a comment");
+        expect(tulist[0].project).toBe("webapp");
+        expect(tulist[0].datatype).toBe("javascript");
+    });
+    test('should add multiple translation units at once to webOS  xliff', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-KR",
+                key: "foobar",
+                file: "foo/bar/asdf.js",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "javascript"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-KR",
+                key: "asdf",
+                file: "x.js",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
+
+        const tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(2);
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("foo/bar/asdf.js");
+        expect(tulist[0].state).toBe("new");
+        expect(tulist[0].comment).toBe("This is a comment");
+        expect(tulist[0].project).toBe("webapp");
+        expect(tulist[0].datatype).toBe("javascript");
+
+        expect(tulist[1].source).toBe("foobar");
+        expect(tulist[1].sourceLocale).toBe("en-KR");
+        expect(tulist[1].key).toBe("asdf");
+        expect(tulist[1].file).toBe("x.js");
+        expect(tulist[1].state).toBe("translated");
+        expect(tulist[1].comment).toBe("No comment");
+        expect(tulist[1].project).toBe("webapp");
+        expect(tulist[1].datatype).toBe("javascript");
+    });
+    test('should return correct size of translation units in webOS  xliff', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+        expect(x.size()).toBe(0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-KR",
+                key: "foobar",
+                file: "foo/bar/asdf.js",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "javascript"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-KR",
+                key: "asdf",
+                file: "x.javascript",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
+        expect(x.size()).toBe(2);
+    });
+});

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -39,6 +39,20 @@ describe("webOSXliff", () => {
         expect(x).toBeTruthy();
         expect(x.size()).toBe(0);
     });
+    test('should get default lines count', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        // default value
+        expect(x.getLines()).toBe(0);
+    });
+    test('should get default bytes count', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        // default value
+        expect(x.getBytes()).toBe(0);
+    });
     test("should create webOSXliff instance with configuration", () => {
         expect.assertions(5);
         var x = new webOSXliff({
@@ -365,6 +379,121 @@ describe("webOSXliff", () => {
 
         expect(actual).toBe(expected);
     });
+    test('should get lines count after deserialization', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+        expect(x.getLines()).toBe(0);
+
+        x.deserialize(
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
+        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '      <group id="sample_g1" name="c">\n' +
+        '        <unit id="1">\n' +
+        '          <segment>\n' +
+        '            <source>Asdf asdf</source>\n' +
+        '            <target>foobarfoo</target>\n' +
+        '          </segment>\n' +
+        '        </unit>\n' +
+        '      </group>\n' +
+        '  </file>\n' +
+        '</xliff>');
+
+        expect(x.getLines()).toBe(13);
+    });
+    test('should get lines count after serialization', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        expect(x.getLines()).toBe(0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        expect(actual).toBeTruthy();
+        expect(x.getLines()).toBe(23);
+    });
+    test('should get bytes count after deserialization', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        expect(x.getBytes()).toBe(0);
+
+        x.deserialize(
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
+        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '      <group id="sample_g1" name="c">\n' +
+        '        <unit id="1">\n' +
+        '          <segment>\n' +
+        '            <source>Asdf asdf</source>\n' +
+        '            <target>foobarfoo</target>\n' +
+        '          </segment>\n' +
+        '        </unit>\n' +
+        '      </group>\n' +
+        '  </file>\n' +
+        '</xliff>');
+
+        expect(x.getBytes()).toBe(417);
+    });
+    test('should get bytes count after serialization', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        expect(x.getBytes()).toBe(0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        expect(actual).toBeTruthy();
+        expect(x.getBytes()).toBe(700);
+    });
     test('should deserialize webOS XLIFF', () => {
         const x = new webOSXliff();
         expect(x).toBeTruthy();
@@ -592,5 +721,73 @@ describe("webOSXliff", () => {
         expect(tulist[1].project).toBe("sample-webos-js");
         expect(tulist[1].resType).toBe("string");
         expect(tulist[1].id).toBe("2");
+    });
+    test('webOSXliffDeserialize_metadata', () => {
+        const x = new webOSXliff({
+            metadata: {"device-type": "SoundBar"}
+        });
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0"\n' +
+        'xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"\n' +
+        'srcLang="en-KR" trgLang="ko-KR">\n' +
+        '  <file id="sample-webos-cs_f1" original="sample-webos-c">\n' +
+        '      <group id="sample-webos-c_g1" name="c">\n' +
+        '        <unit id="1">\n' +
+        '          <mda:metadata>\n' +
+        '            <mda:metaGroup category="device-type">\n' +
+        '              <mda:meta type="Monitor">"Monitor" 이용이 불가능합니다</mda:meta>\n' +
+        '              <mda:meta type="Box">"Box" 이용이 불가능합니다</mda:meta>\n' +
+        '              <mda:meta type="SoundBar">"SoundBar" 이용이 불가능합니다</mda:meta>\n' +
+        '            </mda:metaGroup>\n' +
+        '          </mda:metadata>\n' +
+        '          <segment>\n' +
+        '            <source>NOT AVAILABLE</source>\n' +
+        '            <target>이용이 불가능합니다</target>\n' +
+        '          </segment>\n' +
+        '        </unit>\n' +
+        '      </group>\n' +
+        '  </file>\n' +
+        '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+
+        const expectedMetadata = {
+            "_position": 327,
+            "mda:metaGroup": {
+                "_position": 354,
+                "mda:meta": [
+                    {
+                        "_position": 407,
+                        "_attributes" : {"type": "Monitor"},
+                        "_text": "\"Monitor\" 이용이 불가능합니다"
+                    },
+                    {
+                        "_position": 478,
+                        "_attributes" : {"type": "Box"},
+                        "_text": "\"Box\" 이용이 불가능합니다"
+                    },
+                    {
+                        "_position": 541,
+                        "_attributes" : {"type": "SoundBar"},
+                        "_text": "\"SoundBar\" 이용이 불가능합니다"
+                    }
+                ],
+                "_attributes": {
+                    "category": "device-type"
+                }
+            }
+        }
+
+        expect(tulist[0].source).toBe("NOT AVAILABLE");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].targetLocale).toBe("ko-KR");
+        expect(tulist[0].key).toBe("NOT AVAILABLE");
+        expect(tulist[0].target).toBe("이용이 불가능합니다");
+        expect(tulist[0].metadata).toStrictEqual(expectedMetadata);
     });
 });

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -287,4 +287,310 @@ describe("webOSXliff", () => {
         ]);
         expect(x.size()).toBe(2);
     });
+    test('should serialize XLIFF 2.0 with source only', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" version="2.0">\n' +
+            '  <file id="webapp_f1" original="webapp">\n' +
+            '    <group id="webapp_g1" name="javascript">\n' +
+            '      <unit id="1" name="foobar">\n' +
+            '        <notes>\n' +
+            '          <note>This is a comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+    test('should serialize XLIFF 2.0 with source and target', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-KR",
+            target: "bam bam",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            comment: "This is a comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
+            '  <file id="webapp_f1" original="webapp">\n' +
+            '    <group id="webapp_g1" name="javascript">\n' +
+            '      <unit id="1" name="foobar">\n' +
+            '        <notes>\n' +
+            '          <note>This is a comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '          <target>bam bam</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
+    test('should deserialize webOS XLIFF', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+        '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
+        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '      <group id="sample_g1" name="c">\n' +
+        '        <unit id="1">\n' +
+        '          <segment>\n' +
+        '            <source>Asdf asdf</source>\n' +
+        '            <target>foobarfoo</target>\n' +
+        '          </segment>\n' +
+        '        </unit>\n' +
+        '      </group>\n' +
+        '  </file>\n' +
+        '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].targetLocale).toBe("de-DE");
+        expect(tulist[0].key).toBe("Asdf asdf");
+        expect(tulist[0].target).toBe("foobarfoo");
+    });
+    test('should deserialize XLIFF 2.0 with resfile', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
+                '  <file id="sample_f1" original="sample-webos-c">\n' +
+                '    <group id="sample_g1" name="c">\n' +
+                '      <unit id="1" name="foobar">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>foobarfoo</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file id="sample_f2" original="sample-webos-c">\n' +
+                '    <group id="sample_g2" name="c">\n' +
+                '      <unit id="2" name="huzzah">\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>', "a/b/c/resfile.xliff");
+
+        let tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(2);
+
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("sample-webos-c");
+        expect(tulist[0].project).toBe("sample-webos-c");
+        expect(tulist[0].resType).toBe("string");
+        expect(tulist[0].id).toBe("1");
+        expect(tulist[0].target).toBe("foobarfoo");
+        expect(tulist[0].targetLocale).toBe("de-DE");
+        expect(tulist[0].resfile).toBe("a/b/c/resfile.xliff");
+
+        expect(tulist[1].source).toBe("baby baby");
+        expect(tulist[1].sourceLocale).toBe("en-KR");
+        expect(tulist[1].key).toBe("huzzah");
+        expect(tulist[1].file).toBe("sample-webos-c");
+        expect(tulist[1].project).toBe("sample-webos-c");
+        expect(tulist[1].resType).toBe("string");
+        expect(tulist[1].id).toBe("2");
+        expect(tulist[1].target).toBe("bebe bebe");
+        expect(tulist[1].targetLocale).toBe("de-DE");
+        expect(tulist[1].resfile).toBe("a/b/c/resfile.xliff");
+    });
+    test('should deserialize XLIFF 2.0 with escaped newlines in resname', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-CA" version="2.0">\n' +
+                '  <file id="sample_f1" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="1" name="foobar\\nbar\\t">\n' +
+                '        <segment>\n' +
+                '          <source>a\\nb</source>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file id="sample_f2" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="2" name="huzzah\\n\\na plague on both your houses">\n' +
+                '        <segment>\n' +
+                '          <source>e\\nh</source>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(2);
+
+        expect(tulist[0].source).toBe("a\\nb");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar\\nbar\\t");
+        expect(tulist[0].file).toBe("sample-webos-js");
+        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].resType).toBe("string");
+        expect(tulist[0].id).toBe("1");
+
+        expect(tulist[1].source).toBe("e\\nh");
+        expect(tulist[1].sourceLocale).toBe("en-KR");
+        expect(tulist[1].key).toBe("huzzah\\n\\na plague on both your houses");
+        expect(tulist[1].file).toBe("sample-webos-js");
+        expect(tulist[1].project).toBe("sample-webos-js");
+        expect(tulist[1].resType).toBe("string");
+        expect(tulist[1].id).toBe("2");
+    });
+    test('should deserialize XLIFF 2.0 with empty source', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
+                '  <file id="sample_f1" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="1" name="foobar">\n' +
+                '        <segment>\n' +
+                '          <source></source>\n' +
+                '          <target>Baby Baby</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file id="sample_f2" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="2" name="huzzah">\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(1);
+
+        expect(tulist[0].source).toBe("baby baby");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("huzzah");
+        expect(tulist[0].file).toBe("sample-webos-js");
+        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].resType).toBe("string");
+        expect(tulist[0].id).toBe("2");
+
+        expect(tulist[0].target).toBe("bebe bebe");
+        expect(tulist[0].targetLocale).toBe("fr-FR");
+    });
+
+    test('should deserialize XLIFF 2.0 with empty target', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
+                '  <file id="sample_f1" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="1" name="foobar">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file id="sample_f2" original="sample-webos-js">\n' +
+                '    <group id="sample_g1" name="javascript">\n' +
+                '      <unit id="2" name="huzzah">\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target></target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        expect(tulist).toBeTruthy();
+        expect(tulist.length).toBe(2);
+
+        expect(tulist[0].source).toBe("Asdf asdf");
+        expect(tulist[0].sourceLocale).toBe("en-KR");
+        expect(tulist[0].key).toBe("foobar");
+        expect(tulist[0].file).toBe("sample-webos-js");
+        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].resType).toBe("string");
+        expect(tulist[0].id).toBe("1");
+
+        expect(tulist[1].source).toBe("baby baby");
+        expect(tulist[1].sourceLocale).toBe("en-KR");
+        expect(tulist[1].key).toBe("huzzah");
+        expect(tulist[1].file).toBe("sample-webos-js");
+        expect(tulist[1].project).toBe("sample-webos-js");
+        expect(tulist[1].resType).toBe("string");
+        expect(tulist[1].id).toBe("2");
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,18 @@ importers:
         specifier: 2.31.1
         version: 2.31.1
 
+  packages/ilib-xliff-webos:
+    dependencies:
+      ilib-common:
+        specifier: ^1.1.2
+        version: 1.1.6
+      ilib-xml-js:
+        specifier: ^1.7.0
+        version: 1.7.0
+      jest:
+        specifier: ^30.0.5
+        version: 30.0.5(@types/node@12.20.55)(node-notifier@8.0.2)
+
   packages/samples-lint:
     dependencies:
       ilib-lint:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,10 @@ importers:
         specifier: ^30.0.5
         version: 30.0.5(@types/node@12.20.55)(node-notifier@8.0.2)
 
+  packages/ilib-xliff-webos/src: {}
+
+  packages/ilib-xliff-webos/test: {}
+
   packages/samples-lint:
     dependencies:
       ilib-lint:


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Pass the all tests.
* [x] Include at least one test case for this feature or bug fix.
* [x] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [x] Add API documentation if necessary.

### Description
Create a new `ilib-xliff-webos` for use with loctool and lint
It supports the `serialize` and `deserialize` of the webOS XLIFF file format.

### Links
[//]: # (Related issues, references)

