### PR TITLE
xliff-webos: Assign structured unit IDs with group index during xliff serialization

### DIFF
--- a/.changeset/sweet-kings-nail.md
+++ b/.changeset/sweet-kings-nail.md
@@ -1,5 +1,5 @@
 ---
-"ilib-xliff-webos": minor
+"ilib-xliff-webos": patch
 ---
 
 Assign structured unit IDs with group index during xliff serialization

--- a/.changeset/sweet-kings-nail.md
+++ b/.changeset/sweet-kings-nail.md
@@ -1,0 +1,5 @@
+---
+"ilib-xliff-webos": minor
+---
+
+Assign structured unit IDs with group index during xliff serialization

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -379,6 +379,71 @@ describe("webOSXliff", () => {
 
         expect(actual).toBe(expected);
     });
+    test('should serialize with metadata', () => {
+        const x = new webOSXliff();
+        expect(x).toBeTruthy();
+        const tu = new TranslationUnit({
+            source: "NOT AVAILABLE",
+            sourceLocale: "en-KR",
+            target: "이용이 불가능합니다",
+            targetLocale: "ko-KR",
+            key: "NOT AVAILABLE",
+            file: "foo/bar/asdf.js",
+            project: "webapp",
+            resType: "string",
+            datatype: "javascript"
+        });
+        tu.metadata = {
+            "mda:metaGroup": {
+                "mda:meta": [
+                    {
+                        "_attributes" : {"type": "Monitor"},
+                        "_text": "\"Monitor\" 이용이 불가능합니다"
+                    },
+                    {
+                        "_attributes" : {"type": "Box"},
+                        "_text": "\"Box\" 이용이 불가능합니다"
+                    },
+                    {
+                        "_attributes" : {"type": "SoundBar"},
+                        "_text": "\"SoundBar\" 이용이 불가능합니다"
+                    }
+                ],
+                "_attributes": {
+                    "category": "device-type"
+                }
+            }
+        }
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" ' +
+            'xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0" ' +
+            'srcLang="en-KR" trgLang="ko-KR" version="2.0">\n' +
+            '  <file id="webapp_f1" original="webapp">\n' +
+            '    <group id="webapp_g1" name="javascript">\n' +
+            '      <unit id="webapp_g1_1">\n' +
+            '        <mda:metadata>\n' +
+            '          <mda:metaGroup category="device-type">\n' +
+            '            <mda:meta type="Monitor">"Monitor" 이용이 불가능합니다</mda:meta>\n' +
+            '            <mda:meta type="Box">"Box" 이용이 불가능합니다</mda:meta>\n' +
+            '            <mda:meta type="SoundBar">"SoundBar" 이용이 불가능합니다</mda:meta>\n' +
+            '          </mda:metaGroup>\n' +
+            '        </mda:metadata>\n' +
+            '        <segment>\n' +
+            '          <source>NOT AVAILABLE</source>\n' +
+            '          <target>이용이 불가능합니다</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        expect(actual).toBe(expected);
+    });
     test('should get lines count after deserialization', () => {
         const x = new webOSXliff();
         expect(x).toBeTruthy();
@@ -387,9 +452,9 @@ describe("webOSXliff", () => {
         x.deserialize(
         '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
-        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '  <file id="sample_f1" original="sample">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="webapp_g1_1">\n' +
+        '        <unit id="sample_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -445,9 +510,9 @@ describe("webOSXliff", () => {
         x.deserialize(
         '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
-        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '  <file id="sample_f1" original="sample">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="webapp_g1_1">\n' +
+        '        <unit id="sample_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -457,7 +522,7 @@ describe("webOSXliff", () => {
         '  </file>\n' +
         '</xliff>');
 
-        expect(x.getBytes()).toBe(427);
+        expect(x.getBytes()).toBe(419);
     });
     test('should get bytes count after serialization', () => {
         const x = new webOSXliff();
@@ -501,9 +566,9 @@ describe("webOSXliff", () => {
         x.deserialize(
         '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
-        '  <file id="sample_f1" original="sample-webos-c">\n' +
+        '  <file id="sample_f1" original="sample">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="webapp_g1_1">\n' +
+        '        <unit id="sample_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -530,9 +595,9 @@ describe("webOSXliff", () => {
         x.deserialize(
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
-                '  <file id="sample_f1" original="sample-webos-c">\n' +
-                '    <group id="sample_g1" name="c">\n' +
-                '      <unit id="webapp_g1_1" name="foobar">\n' +
+                '  <file id="sample1_f1" original="sample1">\n' +
+                '    <group id="sample1_g1" name="c">\n' +
+                '      <unit id="sample1_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source>Asdf asdf</source>\n' +
                 '          <target>foobarfoo</target>\n' +
@@ -540,9 +605,9 @@ describe("webOSXliff", () => {
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
-                '  <file id="sample_f2" original="sample-webos-c">\n' +
-                '    <group id="sample_g2" name="c">\n' +
-                '      <unit id="sample_g2_1" name="huzzah">\n' +
+                '  <file id="sample2_f2" original="sample2">\n' +
+                '    <group id="sample2_g2" name="c">\n' +
+                '      <unit id="sample2_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target>bebe bebe</target>\n' +
@@ -560,10 +625,10 @@ describe("webOSXliff", () => {
         expect(tulist[0].source).toBe("Asdf asdf");
         expect(tulist[0].sourceLocale).toBe("en-KR");
         expect(tulist[0].key).toBe("foobar");
-        expect(tulist[0].file).toBe("sample-webos-c");
-        expect(tulist[0].project).toBe("sample-webos-c");
+        expect(tulist[0].file).toBe("sample1");
+        expect(tulist[0].project).toBe("sample1");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("webapp_g1_1");
+        expect(tulist[0].id).toBe("sample1_g1_1");
         expect(tulist[0].target).toBe("foobarfoo");
         expect(tulist[0].targetLocale).toBe("de-DE");
         expect(tulist[0].resfile).toBe("a/b/c/resfile.xliff");
@@ -571,10 +636,10 @@ describe("webOSXliff", () => {
         expect(tulist[1].source).toBe("baby baby");
         expect(tulist[1].sourceLocale).toBe("en-KR");
         expect(tulist[1].key).toBe("huzzah");
-        expect(tulist[1].file).toBe("sample-webos-c");
-        expect(tulist[1].project).toBe("sample-webos-c");
+        expect(tulist[1].file).toBe("sample2");
+        expect(tulist[1].project).toBe("sample2");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("sample_g2_1");
+        expect(tulist[1].id).toBe("sample2_g2_1");
         expect(tulist[1].target).toBe("bebe bebe");
         expect(tulist[1].targetLocale).toBe("de-DE");
         expect(tulist[1].resfile).toBe("a/b/c/resfile.xliff");
@@ -586,18 +651,18 @@ describe("webOSXliff", () => {
         x.deserialize(
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-CA" version="2.0">\n' +
-                '  <file id="sample_f1" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="sample_g1_1" name="foobar\\nbar\\t">\n' +
+                '  <file id="sample1_f1" original="sample1">\n' +
+                '    <group id="sample1_g1" name="javascript">\n' +
+                '      <unit id="sample1_g1_1" name="foobar\\nbar\\t">\n' +
                 '        <segment>\n' +
                 '          <source>a\\nb</source>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
-                '  <file id="sample_f2" original="sample-webos-js">\n' +
-                '    <group id="sample_g2" name="javascript">\n' +
-                '      <unit id="sample_g2_1" name="huzzah\\n\\na plague on both your houses">\n' +
+                '  <file id="sample2_f2" original="sample2">\n' +
+                '    <group id="sample2_g2" name="javascript">\n' +
+                '      <unit id="sample2_g2_1" name="huzzah\\n\\na plague on both your houses">\n' +
                 '        <segment>\n' +
                 '          <source>e\\nh</source>\n' +
                 '        </segment>\n' +
@@ -614,18 +679,18 @@ describe("webOSXliff", () => {
         expect(tulist[0].source).toBe("a\\nb");
         expect(tulist[0].sourceLocale).toBe("en-KR");
         expect(tulist[0].key).toBe("foobar\\nbar\\t");
-        expect(tulist[0].file).toBe("sample-webos-js");
-        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].file).toBe("sample1");
+        expect(tulist[0].project).toBe("sample1");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("sample_g1_1");
+        expect(tulist[0].id).toBe("sample1_g1_1");
 
         expect(tulist[1].source).toBe("e\\nh");
         expect(tulist[1].sourceLocale).toBe("en-KR");
         expect(tulist[1].key).toBe("huzzah\\n\\na plague on both your houses");
-        expect(tulist[1].file).toBe("sample-webos-js");
-        expect(tulist[1].project).toBe("sample-webos-js");
+        expect(tulist[1].file).toBe("sample2");
+        expect(tulist[1].project).toBe("sample2");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("sample_g2_1");
+        expect(tulist[1].id).toBe("sample2_g2_1");
     });
     test('should deserialize XLIFF 2.0 with empty source', () => {
         const x = new webOSXliff();
@@ -634,9 +699,9 @@ describe("webOSXliff", () => {
         x.deserialize(
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
-                '  <file id="sample_f1" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="sample_g1_1" name="foobar">\n' +
+                '  <file id="sample1_f1" original="sample1">\n' +
+                '    <group id="sample1_g1" name="javascript">\n' +
+                '      <unit id="sample1_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source></source>\n' +
                 '          <target>Baby Baby</target>\n' +
@@ -644,9 +709,9 @@ describe("webOSXliff", () => {
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
-                '  <file id="sample_f2" original="sample-webos-js">\n' +
-                '    <group id="sample_g2" name="javascript">\n' +
-                '      <unit id="sample_g2_1" name="huzzah">\n' +
+                '  <file id="sample2_f2" original="sample2">\n' +
+                '    <group id="sample2_g2" name="javascript">\n' +
+                '      <unit id="sample2_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target>bebe bebe</target>\n' +
@@ -664,10 +729,10 @@ describe("webOSXliff", () => {
         expect(tulist[0].source).toBe("baby baby");
         expect(tulist[0].sourceLocale).toBe("en-KR");
         expect(tulist[0].key).toBe("huzzah");
-        expect(tulist[0].file).toBe("sample-webos-js");
-        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].file).toBe("sample2");
+        expect(tulist[0].project).toBe("sample2");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("sample_g2_1");
+        expect(tulist[0].id).toBe("sample2_g2_1");
 
         expect(tulist[0].target).toBe("bebe bebe");
         expect(tulist[0].targetLocale).toBe("fr-FR");
@@ -680,18 +745,18 @@ describe("webOSXliff", () => {
         x.deserialize(
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
-                '  <file id="sample_f1" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="sample_g1_1" name="foobar">\n' +
+                '  <file id="sample1_f1" original="sample1">\n' +
+                '    <group id="sample1_g1" name="javascript">\n' +
+                '      <unit id="sample1_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source>Asdf asdf</source>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
-                '  <file id="sample_f2" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="sample_g2_1" name="huzzah">\n' +
+                '  <file id="sample2_f2" original="sample2">\n' +
+                '    <group id="sample2_g1" name="javascript">\n' +
+                '      <unit id="sample2_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target></target>\n' +
@@ -709,18 +774,18 @@ describe("webOSXliff", () => {
         expect(tulist[0].source).toBe("Asdf asdf");
         expect(tulist[0].sourceLocale).toBe("en-KR");
         expect(tulist[0].key).toBe("foobar");
-        expect(tulist[0].file).toBe("sample-webos-js");
-        expect(tulist[0].project).toBe("sample-webos-js");
+        expect(tulist[0].file).toBe("sample1");
+        expect(tulist[0].project).toBe("sample1");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("sample_g1_1");
+        expect(tulist[0].id).toBe("sample1_g1_1");
 
         expect(tulist[1].source).toBe("baby baby");
         expect(tulist[1].sourceLocale).toBe("en-KR");
         expect(tulist[1].key).toBe("huzzah");
-        expect(tulist[1].file).toBe("sample-webos-js");
-        expect(tulist[1].project).toBe("sample-webos-js");
+        expect(tulist[1].file).toBe("sample2");
+        expect(tulist[1].project).toBe("sample2");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("sample_g2_1");
+        expect(tulist[1].id).toBe("sample2_g2_1");
     });
     test('webOSXliffDeserialize_metadata', () => {
         const x = new webOSXliff({
@@ -733,9 +798,9 @@ describe("webOSXliff", () => {
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0"\n' +
         'xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"\n' +
         'srcLang="en-KR" trgLang="ko-KR">\n' +
-        '  <file id="sample-webos-cs_f1" original="sample-webos-c">\n' +
+        '  <file id="sample-webos-c_f1" original="sample-webos-c">\n' +
         '      <group id="sample-webos-c_g1" name="c">\n' +
-        '        <unit id="1">\n' +
+        '        <unit id="sample-webos-c_g1_1">\n' +
         '          <mda:metadata>\n' +
         '            <mda:metaGroup category="device-type">\n' +
         '              <mda:meta type="Monitor">"Monitor" 이용이 불가능합니다</mda:meta>\n' +
@@ -757,22 +822,22 @@ describe("webOSXliff", () => {
         expect(tulist.length).toBe(1);
 
         const expectedMetadata = {
-            "_position": 327,
+            "_position": 344,
             "mda:metaGroup": {
-                "_position": 354,
+                "_position": 371,
                 "mda:meta": [
                     {
-                        "_position": 407,
+                        "_position": 424,
                         "_attributes" : {"type": "Monitor"},
                         "_text": "\"Monitor\" 이용이 불가능합니다"
                     },
                     {
-                        "_position": 478,
+                        "_position": 495,
                         "_attributes" : {"type": "Box"},
                         "_text": "\"Box\" 이용이 불가능합니다"
                     },
                     {
-                        "_position": 541,
+                        "_position": 558,
                         "_attributes" : {"type": "SoundBar"},
                         "_text": "\"SoundBar\" 이용이 불가능합니다"
                     }

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -140,7 +140,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].sourceLocale).toBe("en-KR");
         expect(tulist[0].key).toBe("foobar");
         expect(tulist[0].file).toBe("foo/bar/asdf.js");
-        expect(tulist[0].state).toBe("new"); 
+        expect(tulist[0].state).toBe("new");
         expect(tulist[0].comment).toBe("This is a comment");
         expect(tulist[0].project).toBe("webapp");
         expect(tulist[0].datatype).toBe("javascript");
@@ -325,7 +325,7 @@ describe("webOSXliff", () => {
             '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" version="2.0">\n' +
             '  <file id="webapp_f1" original="webapp">\n' +
             '    <group id="webapp_g1" name="javascript">\n' +
-            '      <unit id="1" name="foobar">\n' +
+            '      <unit id="webapp_g1_1" name="foobar">\n' +
             '        <notes>\n' +
             '          <note>This is a comment</note>\n' +
             '        </notes>\n' +
@@ -364,7 +364,7 @@ describe("webOSXliff", () => {
             '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
             '  <file id="webapp_f1" original="webapp">\n' +
             '    <group id="webapp_g1" name="javascript">\n' +
-            '      <unit id="1" name="foobar">\n' +
+            '      <unit id="webapp_g1_1" name="foobar">\n' +
             '        <notes>\n' +
             '          <note>This is a comment</note>\n' +
             '        </notes>\n' +
@@ -389,7 +389,7 @@ describe("webOSXliff", () => {
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
         '  <file id="sample_f1" original="sample-webos-c">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="1">\n' +
+        '        <unit id="webapp_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -447,7 +447,7 @@ describe("webOSXliff", () => {
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
         '  <file id="sample_f1" original="sample-webos-c">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="1">\n' +
+        '        <unit id="webapp_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -457,7 +457,7 @@ describe("webOSXliff", () => {
         '  </file>\n' +
         '</xliff>');
 
-        expect(x.getBytes()).toBe(417);
+        expect(x.getBytes()).toBe(427);
     });
     test('should get bytes count after serialization', () => {
         const x = new webOSXliff();
@@ -492,7 +492,7 @@ describe("webOSXliff", () => {
 
         let actual = x.serialize();
         expect(actual).toBeTruthy();
-        expect(x.getBytes()).toBe(700);
+        expect(x.getBytes()).toBe(724);
     });
     test('should deserialize webOS XLIFF', () => {
         const x = new webOSXliff();
@@ -503,7 +503,7 @@ describe("webOSXliff", () => {
         '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
         '  <file id="sample_f1" original="sample-webos-c">\n' +
         '      <group id="sample_g1" name="c">\n' +
-        '        <unit id="1">\n' +
+        '        <unit id="webapp_g1_1">\n' +
         '          <segment>\n' +
         '            <source>Asdf asdf</source>\n' +
         '            <target>foobarfoo</target>\n' +
@@ -532,7 +532,7 @@ describe("webOSXliff", () => {
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">\n' +
                 '  <file id="sample_f1" original="sample-webos-c">\n' +
                 '    <group id="sample_g1" name="c">\n' +
-                '      <unit id="1" name="foobar">\n' +
+                '      <unit id="webapp_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source>Asdf asdf</source>\n' +
                 '          <target>foobarfoo</target>\n' +
@@ -542,7 +542,7 @@ describe("webOSXliff", () => {
                 '  </file>\n' +
                 '  <file id="sample_f2" original="sample-webos-c">\n' +
                 '    <group id="sample_g2" name="c">\n' +
-                '      <unit id="2" name="huzzah">\n' +
+                '      <unit id="sample_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target>bebe bebe</target>\n' +
@@ -563,7 +563,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].file).toBe("sample-webos-c");
         expect(tulist[0].project).toBe("sample-webos-c");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("1");
+        expect(tulist[0].id).toBe("webapp_g1_1");
         expect(tulist[0].target).toBe("foobarfoo");
         expect(tulist[0].targetLocale).toBe("de-DE");
         expect(tulist[0].resfile).toBe("a/b/c/resfile.xliff");
@@ -574,7 +574,7 @@ describe("webOSXliff", () => {
         expect(tulist[1].file).toBe("sample-webos-c");
         expect(tulist[1].project).toBe("sample-webos-c");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("2");
+        expect(tulist[1].id).toBe("sample_g2_1");
         expect(tulist[1].target).toBe("bebe bebe");
         expect(tulist[1].targetLocale).toBe("de-DE");
         expect(tulist[1].resfile).toBe("a/b/c/resfile.xliff");
@@ -588,7 +588,7 @@ describe("webOSXliff", () => {
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-CA" version="2.0">\n' +
                 '  <file id="sample_f1" original="sample-webos-js">\n' +
                 '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="1" name="foobar\\nbar\\t">\n' +
+                '      <unit id="sample_g1_1" name="foobar\\nbar\\t">\n' +
                 '        <segment>\n' +
                 '          <source>a\\nb</source>\n' +
                 '        </segment>\n' +
@@ -596,8 +596,8 @@ describe("webOSXliff", () => {
                 '    </group>\n' +
                 '  </file>\n' +
                 '  <file id="sample_f2" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="2" name="huzzah\\n\\na plague on both your houses">\n' +
+                '    <group id="sample_g2" name="javascript">\n' +
+                '      <unit id="sample_g2_1" name="huzzah\\n\\na plague on both your houses">\n' +
                 '        <segment>\n' +
                 '          <source>e\\nh</source>\n' +
                 '        </segment>\n' +
@@ -617,7 +617,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].file).toBe("sample-webos-js");
         expect(tulist[0].project).toBe("sample-webos-js");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("1");
+        expect(tulist[0].id).toBe("sample_g1_1");
 
         expect(tulist[1].source).toBe("e\\nh");
         expect(tulist[1].sourceLocale).toBe("en-KR");
@@ -625,7 +625,7 @@ describe("webOSXliff", () => {
         expect(tulist[1].file).toBe("sample-webos-js");
         expect(tulist[1].project).toBe("sample-webos-js");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("2");
+        expect(tulist[1].id).toBe("sample_g2_1");
     });
     test('should deserialize XLIFF 2.0 with empty source', () => {
         const x = new webOSXliff();
@@ -636,7 +636,7 @@ describe("webOSXliff", () => {
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
                 '  <file id="sample_f1" original="sample-webos-js">\n' +
                 '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="1" name="foobar">\n' +
+                '      <unit id="sample_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source></source>\n' +
                 '          <target>Baby Baby</target>\n' +
@@ -645,8 +645,8 @@ describe("webOSXliff", () => {
                 '    </group>\n' +
                 '  </file>\n' +
                 '  <file id="sample_f2" original="sample-webos-js">\n' +
-                '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="2" name="huzzah">\n' +
+                '    <group id="sample_g2" name="javascript">\n' +
+                '      <unit id="sample_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target>bebe bebe</target>\n' +
@@ -667,7 +667,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].file).toBe("sample-webos-js");
         expect(tulist[0].project).toBe("sample-webos-js");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("2");
+        expect(tulist[0].id).toBe("sample_g2_1");
 
         expect(tulist[0].target).toBe("bebe bebe");
         expect(tulist[0].targetLocale).toBe("fr-FR");
@@ -682,7 +682,7 @@ describe("webOSXliff", () => {
                 '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">\n' +
                 '  <file id="sample_f1" original="sample-webos-js">\n' +
                 '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="1" name="foobar">\n' +
+                '      <unit id="sample_g1_1" name="foobar">\n' +
                 '        <segment>\n' +
                 '          <source>Asdf asdf</source>\n' +
                 '        </segment>\n' +
@@ -691,7 +691,7 @@ describe("webOSXliff", () => {
                 '  </file>\n' +
                 '  <file id="sample_f2" original="sample-webos-js">\n' +
                 '    <group id="sample_g1" name="javascript">\n' +
-                '      <unit id="2" name="huzzah">\n' +
+                '      <unit id="sample_g2_1" name="huzzah">\n' +
                 '        <segment>\n' +
                 '          <source>baby baby</source>\n' +
                 '          <target></target>\n' +
@@ -712,7 +712,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].file).toBe("sample-webos-js");
         expect(tulist[0].project).toBe("sample-webos-js");
         expect(tulist[0].resType).toBe("string");
-        expect(tulist[0].id).toBe("1");
+        expect(tulist[0].id).toBe("sample_g1_1");
 
         expect(tulist[1].source).toBe("baby baby");
         expect(tulist[1].sourceLocale).toBe("en-KR");
@@ -720,7 +720,7 @@ describe("webOSXliff", () => {
         expect(tulist[1].file).toBe("sample-webos-js");
         expect(tulist[1].project).toBe("sample-webos-js");
         expect(tulist[1].resType).toBe("string");
-        expect(tulist[1].id).toBe("2");
+        expect(tulist[1].id).toBe("sample_g2_1");
     });
     test('webOSXliffDeserialize_metadata', () => {
         const x = new webOSXliff({


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Pass the all tests.
* [x] Include at least one test case for this feature or bug fix.
* [x] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [x] Add API documentation if necessary.

### Description
[//]: # (Describe the issue resolved or feature added by this pull request)
* Unit IDs are now generated in the format `<project>_g<groupIndex>_<unitIndex>`, e.g., sample_g1_1
* During XLIFF serialization, file, group, and unit indices are reassigned from scratch based on the current content structure.

### Links
[//]: # (Related issues, references)
* original PR: https://github.com/iLib-js/ilib-mono/pull/189

