### PR TITLE
xliff-webos: Fix a bug where the target is stored incorrectly when the value is empty

### DIFF
--- a/.changeset/gold-monkeys-visit.md
+++ b/.changeset/gold-monkeys-visit.md
@@ -1,0 +1,5 @@
+---
+"ilib-xliff-webos": patch
+---
+
+Fix a bug where the target is stored incorrectly when the value is empty

--- a/packages/ilib-xliff-webos/src/webOSXliff.js
+++ b/packages/ilib-xliff-webos/src/webOSXliff.js
@@ -468,9 +468,9 @@ class webOSXliff {
                                 for (let j = 0; j < segments.length; j++) {
                                     let segment = segments[j];
                                     if (segment.source["_text"]) {
-                                        source += segment.source["_text"];
+                                        source += segment.source["_text"] ?? "";
                                         if (segment.target) {
-                                            target += segment.target["_text"];
+                                            target += segment.target["_text"] ?? "";
                                             if (segment.target.state) {
                                                 state = segment.target._attributes.state;
                                             }

--- a/packages/ilib-xliff-webos/test/webOSXliff.test.js
+++ b/packages/ilib-xliff-webos/test/webOSXliff.test.js
@@ -778,6 +778,7 @@ describe("webOSXliff", () => {
         expect(tulist[0].project).toBe("sample1");
         expect(tulist[0].resType).toBe("string");
         expect(tulist[0].id).toBe("sample1_g1_1");
+        expect(tulist[0].target).toBe("");
 
         expect(tulist[1].source).toBe("baby baby");
         expect(tulist[1].sourceLocale).toBe("en-KR");
@@ -785,6 +786,7 @@ describe("webOSXliff", () => {
         expect(tulist[1].file).toBe("sample2");
         expect(tulist[1].project).toBe("sample2");
         expect(tulist[1].resType).toBe("string");
+        expect(tulist[1].target).toBe("");
         expect(tulist[1].id).toBe("sample2_g2_1");
     });
     test('webOSXliffDeserialize_metadata', () => {


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
Fix a bug where the target is stored incorrectly when the value is empty.
Previously, when the xliff contained `<target></target>`, the value was stored as '"undefined"' In this case, the lint tool's rule cannot properly detect the issue. (rule:resouce-completeness)

### Links
[//]: # (Related issues, references)

