### PR TITLE
Modify release.yml to fix the release failure.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     push:
         branches:
             - main
+    workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,11 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     release:
         name: Release
-        environment: Release
+        runs-on: ubuntu-latest
         permissions:
-            id-token: write
             contents: write
             pull-requests: write
-        runs-on: ubuntu-latest
+            id-token: write
         strategy:
             matrix:
                 node-version: [20]
@@ -30,13 +29,6 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: pnpm
-                  registry-url: "https://registry.npmjs.org/"
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-            # Ensure npm 11.5.1 or later is installed so we can publish to npm with OIDC
-            # per https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-            #- name: Force update npm
-            #  run: npm install -g npm@latest
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
             - name: Create Release Pull Request or Publish to npm
@@ -46,6 +38,3 @@ jobs:
                   publish: pnpm release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  # Workaround to use OIDC in changeset action
-                  # per https://github.com/changesets/action/issues/542
-                  NPM_TOKEN: ""


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
https://github.com/iLib-js/ilib-mono-webos/actions/runs/24485231367
```
🦋  error an error occurred while publishing ilib-loctool-webos-javascript: E404 Not Found - PUT https://registry.npmjs.org/ilib-loctool-webos-javascript - Not found 
🦋  error 'ilib-loctool-webos-javascript@1.13.2' is not in this registry.
🦋  error 
🦋  error Note that you can also install from a
🦋  error tarball, folder, http url, or git url.
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
🦋  error npm error code E404
🦋  error npm error 404 Not Found - PUT https://registry.npmjs.org/ilib-loctool-webos-javascript - Not found
🦋  error npm error 404
🦋  error npm error 404  'ilib-loctool-webos-javascript@1.13.2' is not in this registry.
🦋  error npm error 404
🦋  error npm error 404 Note that you can also install from a
🦋  error npm error 404 tarball, folder, http url, or git url.
🦋  error npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-16T00_21_44_338Z-debug-0.log
🦋  error 
......

```

### Links
