### PR TITLE
Update dependencies (loctool: 2.33.0) and derive webOS project type from plugins

### DIFF
--- a/.changeset/cool-jeans-greet.md
+++ b/.changeset/cool-jeans-greet.md
@@ -1,0 +1,31 @@
+---
+"ilib-loctool-mock-resource": patch
+"integration-sample-webos-js": patch
+"integration-sample-webos-dart": patch
+"integration-sample-webos-json": patch
+"integration-sample-webos-cpp": patch
+"integration-sample-webos-qml": patch
+"integration-sample-webos-c": patch
+"sample-webos-json-subdir": patch
+"ilib-loctool-webos-json-resource": patch
+"ilib-loctool-webos-ts-resource": patch
+"ilib-loctool-webos-javascript": patch
+"sample-webos-dart": patch
+"sample-webos-json": patch
+"ilib-loctool-webos-common": patch
+"sample-webos-cpp": patch
+"sample-webos-qml": patch
+"sample-webos-js": patch
+"ilib-loctool-webos-dart": patch
+"ilib-loctool-webos-dist": patch
+"ilib-loctool-webos-json": patch
+"sample-webos-c": patch
+"ilib-loctool-webos-cpp": patch
+"ilib-loctool-webos-qml": patch
+"ilib-loctool-webos-c": patch
+"ilib-xliff-webos": patch
+"ilib-lint-webos": patch
+"lint-webos-sample": patch
+---
+
+Update dependencies (loctool: 2.33.0)

--- a/.changeset/cool-jeans-greet.md
+++ b/.changeset/cool-jeans-greet.md
@@ -1,25 +1,11 @@
 ---
-"ilib-loctool-mock-resource": patch
-"integration-sample-webos-js": patch
-"integration-sample-webos-dart": patch
-"integration-sample-webos-json": patch
-"integration-sample-webos-cpp": patch
-"integration-sample-webos-qml": patch
-"integration-sample-webos-c": patch
-"sample-webos-json-subdir": patch
 "ilib-loctool-webos-json-resource": patch
 "ilib-loctool-webos-ts-resource": patch
 "ilib-loctool-webos-javascript": patch
-"sample-webos-dart": patch
-"sample-webos-json": patch
 "ilib-loctool-webos-common": patch
-"sample-webos-cpp": patch
-"sample-webos-qml": patch
-"sample-webos-js": patch
 "ilib-loctool-webos-dart": patch
 "ilib-loctool-webos-dist": patch
 "ilib-loctool-webos-json": patch
-"sample-webos-c": patch
 "ilib-loctool-webos-cpp": patch
 "ilib-loctool-webos-qml": patch
 "ilib-loctool-webos-c": patch

--- a/.changeset/wild-teams-allow.md
+++ b/.changeset/wild-teams-allow.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-json-resource": patch
+---
+
+Support custom projectType

--- a/.changeset/wild-teams-allow.md
+++ b/.changeset/wild-teams-allow.md
@@ -2,4 +2,4 @@
 "ilib-loctool-webos-json-resource": patch
 ---
 
-Support custom projectType
+Drive projectType from plugins

--- a/packages/ilib-lint-webos/package.json
+++ b/packages/ilib-lint-webos/package.json
@@ -66,7 +66,7 @@
     },
     "devDependencies": {
         "docdash": "^2.0.2",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "jsdoc": "^4.0.5",
         "jsdoc-to-markdown": "^9.1.3",
         "npm-run-all": "^4.1.5",

--- a/packages/ilib-loctool-webos-c/package.json
+++ b/packages/ilib-loctool-webos-c/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -47,7 +47,6 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -1,7 +1,7 @@
 /*
  * CApp.test.js - test the localization result of webos-c app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-c",
-            projectType: "webos-c",
+            projectType: "custom",
             sourceLocale: "en-KR",
             pseudoLocale : {
                 "zxx-XX": "debug"
@@ -47,6 +47,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
+            projectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -47,7 +47,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
-            projectType: "webos-c",
+            customProjectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
@@ -45,7 +45,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
-            projectType: "webos-c",
+            customProjectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "generate",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * CApp.test.js - test the localization result of webos-c app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-c",
-            projectType: "webos-c",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "resources2" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
@@ -45,6 +45,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
+            projectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "generate",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
@@ -45,7 +45,6 @@ describe("[integration] test the localization result of webos-c app", () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-c",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "generate",

--- a/packages/ilib-loctool-webos-c/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-c": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-common/package.json
+++ b/packages/ilib-loctool-webos-common/package.json
@@ -36,10 +36,10 @@
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource/package.json
+++ b/packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource/package.json
@@ -25,6 +25,6 @@
         "MockResourceFile.js"
     ],
     "dependencies": {
-        "ilib": "^14.21.3"
+        "ilib": "^14.22.0"
     }
 }

--- a/packages/ilib-loctool-webos-cpp/package.json
+++ b/packages/ilib-loctool-webos-cpp/package.json
@@ -57,10 +57,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -1,7 +1,7 @@
 /*
  * CppApp.test.js - test the localization result in localize mode of webos-cpp app
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-cpp",
-            projectType: "webos-cpp",
+            projectType: "custom",
             sourceLocale: "en-KR",
             pseudoLocale : {
                 "zxx-XX": "debug"
@@ -47,6 +47,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
+            projectType: "webos-cpp",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -47,7 +47,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
-            projectType: "webos-cpp",
+            customProjectType: "webos-cpp",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -47,7 +47,6 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-cpp",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * CppApp.test.js - test the localization result in generate mode of webos-cpp app
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-cpp",
-            projectType: "webos-cpp",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "resources2" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
@@ -45,6 +45,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
+            projectType: "webos-cpp",
             localizeOnly: true,
             translationsDir: "./xliffs",
             mode: "generate",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
@@ -45,7 +45,6 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-cpp",
             localizeOnly: true,
             translationsDir: "./xliffs",
             mode: "generate",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
@@ -45,7 +45,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         };
 
         const appSettings = {
-            projectType: "webos-cpp",
+            customProjectType: "webos-cpp",
             localizeOnly: true,
             translationsDir: "./xliffs",
             mode: "generate",

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-cpp": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-dart/package.json
+++ b/packages/ilib-loctool-webos-dart/package.json
@@ -54,14 +54,14 @@
     "dependencies": {
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -46,7 +46,6 @@ describe('[integration] test the localization result of webos-dart app', () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-dart",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -1,7 +1,7 @@
 /*
  * DartApp.test.js - test the localization result of webos-dart app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-dart",
-            projectType: "webos-dart",
+            projectType: "custom",
             sourceLocale: "en-KR",
             pseudoLocale : {
                 "zxx-XX": "debug"
@@ -46,6 +46,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         };
 
         const appSettings = {
+            projectType: "webos-dart",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -46,7 +46,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         };
 
         const appSettings = {
-            projectType: "webos-dart",
+            customProjectType: "webos-dart",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * DartAppGenerate.test.js - test the localization result in generate mode of webos-dart app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,13 +37,14 @@ describe('[integration] test the localization result (generate mode) of webos-da
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-dart",
-            projectType: "webos-dart",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "assets2/i18n" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
             plugins: [ "ilib-loctool-webos-dart" ]
         };
         const appSettings = {
+            projectType: "webos-dart",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             metadata : {

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
@@ -44,7 +44,7 @@ describe('[integration] test the localization result (generate mode) of webos-da
             plugins: [ "ilib-loctool-webos-dart" ]
         };
         const appSettings = {
-            projectType: "webos-dart",
+            customProjectType: "webos-dart",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             metadata : {

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
@@ -44,7 +44,6 @@ describe('[integration] test the localization result (generate mode) of webos-da
             plugins: [ "ilib-loctool-webos-dart" ]
         };
         const appSettings = {
-            customProjectType: "webos-dart",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             metadata : {

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-dart": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-dist/package.json
+++ b/packages/ilib-loctool-webos-dist/package.json
@@ -37,6 +37,6 @@
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/package.json
+++ b/packages/ilib-loctool-webos-javascript/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -33,7 +33,7 @@ describe('[integration] test the localization result of webos-js app', () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-js",
-            projectType: "webos-js",
+            projectType: "custom",
             sourceLocale: "en-KR",
             "pseudoLocale" : {
                 "zxx-XX": "debug",
@@ -45,6 +45,7 @@ describe('[integration] test the localization result of webos-js app', () => {
         };
 
         const appSettings = {
+            projectType: "webos-js",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -45,7 +45,6 @@ describe('[integration] test the localization result of webos-js app', () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-js",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -45,7 +45,7 @@ describe('[integration] test the localization result of webos-js app', () => {
         };
 
         const appSettings = {
-            projectType: "webos-js",
+            customProjectType: "webos-js",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -41,7 +41,6 @@ describe('[integration] test the localization result (generate mode) of webos-js
             plugins: [ "ilib-loctool-webos-javascript" ]
         };
         const appSettings = {
-            customProjectType: "webos-js",
             localizeOnly: true,
             translationsDir: "./xliffs",
             xliffStyle: "webOS",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -41,7 +41,7 @@ describe('[integration] test the localization result (generate mode) of webos-js
             plugins: [ "ilib-loctool-webos-javascript" ]
         };
         const appSettings = {
-            projectType: "webos-js",
+            customProjectType: "webos-js",
             localizeOnly: true,
             translationsDir: "./xliffs",
             xliffStyle: "webOS",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * JsAppGenerate.test.js - test the localization result in generate mode of webos-js app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,14 @@ describe('[integration] test the localization result (generate mode) of webos-js
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-js",
-            projectType: "webos-js",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "resources2" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
             plugins: [ "ilib-loctool-webos-javascript" ]
         };
         const appSettings = {
+            projectType: "webos-js",
             localizeOnly: true,
             translationsDir: "./xliffs",
             xliffStyle: "webOS",

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -14,10 +14,10 @@
     "dependencies": {
         "ilib-loctool-webos-javascript": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "ilib": "^14.21.3",
-        "jest": "^30.3.0"
+        "ilib": "^14.22.0",
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/nested/agate/project.json
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/nested/agate/project.json
@@ -14,7 +14,6 @@
         "ilib-loctool-webos-appinfo-json"
     ],
     "settings": {
-        "customProjectType": "webos-web",
         "locales": ["ko-KR", "en-US"],
         "translationsDir": "agate-xliff"
 	}

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/nested/agate/project.json
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/nested/agate/project.json
@@ -1,7 +1,7 @@
 {
     "name": "agate",
     "id": "agate",
-    "projectType": "webos-web",
+    "projectType": "custom",
     "pseudoLocale": ["zxx-XX"],
     "resourceDirs": {
         "json":"resources"
@@ -14,6 +14,7 @@
         "ilib-loctool-webos-appinfo-json"
     ],
     "settings": {
+        "customProjectType": "webos-web",
         "locales": ["ko-KR", "en-US"],
         "translationsDir": "agate-xliff"
 	}

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/nested/project.json
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/nested/project.json
@@ -14,7 +14,6 @@
         "ilib-loctool-webos-appinfo-json"
     ],
     "settings": {
-        "customProjectType": "webos-web",
         "locales": ["ko-KR", "en-US"],
         "translationsDir": "sample-xliff"
 	}

--- a/packages/ilib-loctool-webos-javascript/test/testfiles/nested/project.json
+++ b/packages/ilib-loctool-webos-javascript/test/testfiles/nested/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample",
     "id": "sample",
-    "projectType": "webos-web",
+    "projectType": "custom",
     "pseudoLocale": ["zxx-XX"],
     "resourceDirs": {
         "json":"resources"
@@ -14,6 +14,7 @@
         "ilib-loctool-webos-appinfo-json"
     ],
     "settings": {
+        "customProjectType": "webos-web",
         "locales": ["ko-KR", "en-US"],
         "translationsDir": "sample-xliff"
 	}

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.js - represents an JSON style resource file
  *
- * Copyright (c) 2019-2025, JEDLSoft
+ * Copyright (c) 2019-2026, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -152,11 +152,12 @@ JSONResourceFile.prototype.getDefaultSpec = function() {
  * so webOS projects use `projectType: "custom"` and do not store their concrete type there.
  * This method derives the effective type from configured webOS plugins: it returns the first
  * known type (webos-c/webos-cpp/webos-dart) after stripping the `ilib-loctool-` prefix.
- * If no matching plugin is found, it falls back to "webos-web".
+ * `webos-javascript` is treated as `webos-javascript`.
+ * If no matching plugin is found, it falls back to "webos-javascript".
  * `plugins` is read from `project.options` first, then `project.settings`.
  *
  * @private
- * @returns {String} the webOS project type (e.g. "webos-cpp", "webos-dart", "webos-web")
+ * @returns {String} the webOS project type (e.g. "webos-cpp", "webos-dart", "webos-javascript")
  */
 JSONResourceFile.prototype._getProjectType = function() {
     const plugins =
@@ -167,19 +168,19 @@ JSONResourceFile.prototype._getProjectType = function() {
         "webos-c",
         "webos-cpp",
         "webos-dart",
+        "webos-javascript",
     ];
 
     if (plugins) {
         for (var i = 0; i < plugins.length; i++) {
             var pluginName = plugins[i].replace(/^ilib-loctool-/, "");
-
             if (typedPlugins.indexOf(pluginName) > -1) {
                 return pluginName;
             }
         }
     }
 
-    return "webos-web";
+    return "webos-javascript";
 };
 
 /**

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -151,14 +151,14 @@ JSONResourceFile.prototype.getDefaultSpec = function() {
  * The top-level `projectType` in the project config is restricted to a
  * fixed whitelist (android/iosobjc/swift/web/custom), so webOS projects must declare
  * `projectType: "custom"` there and preserve their real type (e.g. "webos-cpp") in
- * `settings.projectType`. Prefer that value; fall back to the top-level project type
+ * `settings.customProjectType`. Prefer that value; fall back to the top-level project type
  * for backward compatibility with older configs and unit tests that inject it directly.
  *
  * @private
  * @returns {String|undefined} the webOS project type (e.g. "webos-cpp", "webos-dart")
  */
 JSONResourceFile.prototype._getProjectType = function() {
-    return (this.project.settings && this.project.settings.projectType) || this.project.getProjectType();
+    return (this.project.settings && this.project.settings.customProjectType) || this.project.getProjectType();
 };
 
 /**

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -148,17 +148,38 @@ JSONResourceFile.prototype.getDefaultSpec = function() {
 /**
  * Return the effective webOS project type.
  *
- * The top-level `projectType` in the project config is restricted to a
- * fixed whitelist (android/iosobjc/swift/web/custom), so webOS projects must declare
- * `projectType: "custom"` there and preserve their real type (e.g. "webos-cpp") in
- * `settings.customProjectType`. Prefer that value; fall back to the top-level project type
- * for backward compatibility with older configs and unit tests that inject it directly.
+ * The `projectType` field is limited to a fixed whitelist (android/iosobjc/swift/web/custom),
+ * so webOS projects use `projectType: "custom"` and do not store their concrete type there.
+ * This method derives the effective type from configured webOS plugins: it returns the first
+ * known type (webos-c/webos-cpp/webos-dart) after stripping the `ilib-loctool-` prefix.
+ * If no matching plugin is found, it falls back to "webos-web".
+ * `plugins` is read from `project.options` first, then `project.settings`.
  *
  * @private
- * @returns {String|undefined} the webOS project type (e.g. "webos-cpp", "webos-dart")
+ * @returns {String} the webOS project type (e.g. "webos-cpp", "webos-dart", "webos-web")
  */
 JSONResourceFile.prototype._getProjectType = function() {
-    return (this.project.settings && this.project.settings.customProjectType) || this.project.getProjectType();
+    const plugins =
+        (this.project.options && this.project.options.plugins) ||
+        (this.project.settings && this.project.settings.plugins);
+
+    var typedPlugins = [
+        "webos-c",
+        "webos-cpp",
+        "webos-dart",
+    ];
+
+    if (plugins) {
+        for (var i = 0; i < plugins.length; i++) {
+            var pluginName = plugins[i].replace(/^ilib-loctool-/, "");
+
+            if (typedPlugins.indexOf(pluginName) > -1) {
+                return pluginName;
+            }
+        }
+    }
+
+    return "webos-web";
 };
 
 /**

--- a/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
+++ b/packages/ilib-loctool-webos-json-resource/JSONResourceFile.js
@@ -146,10 +146,26 @@ JSONResourceFile.prototype.getDefaultSpec = function() {
 };
 
 /**
+ * Return the effective webOS project type.
+ *
+ * The top-level `projectType` in the project config is restricted to a
+ * fixed whitelist (android/iosobjc/swift/web/custom), so webOS projects must declare
+ * `projectType: "custom"` there and preserve their real type (e.g. "webos-cpp") in
+ * `settings.projectType`. Prefer that value; fall back to the top-level project type
+ * for backward compatibility with older configs and unit tests that inject it directly.
+ *
+ * @private
+ * @returns {String|undefined} the webOS project type (e.g. "webos-cpp", "webos-dart")
+ */
+JSONResourceFile.prototype._getProjectType = function() {
+    return (this.project.settings && this.project.settings.projectType) || this.project.getProjectType();
+};
+
+/**
  * @private
  */
 JSONResourceFile.prototype._isPluralData = function(data) {
-    if (this.project.getProjectType() !== 'webos-dart') return false;
+    if (this._getProjectType() !== 'webos-dart') return false;
 
     if ((data.indexOf("#") > -1) && (data.indexOf("|") > -1)) {
         return true;
@@ -278,8 +294,8 @@ JSONResourceFile.prototype.getResourceFilePath = function(locale, flavor) {
     if (this.project.settings.resourceFileNames && this.project.settings.resourceFileNames["json"]){
         filename = this.project.settings.resourceFileNames["json"];
     }
-    if (this.project.options.projectType) {
-        var projectType = this.project.getProjectType().split("-");
+    if (this._getProjectType()) {
+        var projectType = this._getProjectType().split("-");
         type = projectType[1];
         if (projectType[1] === "c" || projectType[1] === "cpp") {
             filename = this.project.settings.resourceFileNames[projectType[1]];
@@ -328,7 +344,7 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
         files: []
     };
 
-    if (this.project.getProjectType() === 'webos-dart') {
+    if (this._getProjectType() === 'webos-dart') {
         filePath = path.join(this.project.target, "assets/i18n");
     }
 
@@ -354,7 +370,7 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
     }
 
     walk(filePath, "");
-    var manifestFilePath = (this.project.getProjectType() === 'webos-dart') ?
+    var manifestFilePath = (this._getProjectType() === 'webos-dart') ?
                            path.join(filePath, "fluttermanifest.json") : path.join(filePath, "ilibmanifest.json");
     var readManifest, data;
     if (fs.existsSync(manifestFilePath)) {

--- a/packages/ilib-loctool-webos-json-resource/package.json
+++ b/packages/ilib-loctool-webos-json-resource/package.json
@@ -54,13 +54,13 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3"
+        "ilib": "^14.22.0"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -46,7 +46,7 @@ var p = new CustomProject({
         "json": "localized_json"
         }
     }, "./testfiles", {
-        projectType: "webos-web",
+        customProjectType: "webos-web",
         locales:["en-GB"]
     });
 
@@ -58,7 +58,7 @@ var p2 = new CustomProject({
         "json": "localized_json"
         }
     }, "./testfiles", {
-    projectType: "webos-web",
+        customProjectType: "webos-web",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
@@ -68,7 +68,7 @@ var p3 = new CustomProject({
     projectType: "custom",
     sourceLocale: "en-KR",
     }, "./testfiles", {
-    projectType: "webos-dart",
+    customProjectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {
@@ -87,7 +87,7 @@ var p4 = new CustomProject({
         "json": "assets/i18n"
         }
     }, "./testfiles", {
-    projectType: "webos-dart",
+    customProjectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.test.js - test the JavaScript file handler object.
  *
- * Copyright (c) 2019-2025 JEDLSoft
+ * Copyright (c) 2019-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,32 +40,35 @@ function diff(a, b) {
 
 var p = new CustomProject({
     id: "webosApp",
-    projectType: "webos-web",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
         }
     }, "./testfiles", {
+        projectType: "webos-web",
         locales:["en-GB"]
     });
 
 var p2 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-web",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
         }
     }, "./testfiles", {
+    projectType: "webos-web",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
 
 var p3 = new CustomProject({
     id: "flutterHome",
-    projectType: "webos-dart",
+    projectType: "custom",
     sourceLocale: "en-KR",
     }, "./testfiles", {
+    projectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {
@@ -78,12 +81,13 @@ var p3 = new CustomProject({
 
 var p4 = new CustomProject({
     id: "flutterHome",
-    projectType: "webos-dart",
+    projectType: "custom",
     sourceLocale: "en-KR",
     resourceDirs: {
         "json": "assets/i18n"
         }
     }, "./testfiles", {
+    projectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFile.test.js
@@ -44,9 +44,9 @@ var p = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
-        }
+    },
+    plugins: [ "ilib-loctool-webos-javascript" ]
     }, "./testfiles", {
-        customProjectType: "webos-web",
         locales:["en-GB"]
     });
 
@@ -56,19 +56,19 @@ var p2 = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
-        }
+    },
+    plugins: [ "ilib-loctool-webos-javascript" ]
     }, "./testfiles", {
-        customProjectType: "webos-web",
-    locales:["en-GB", "de-DE", "de-AT"],
-    identify: true
+        locales:["en-GB", "de-DE", "de-AT"],
+        identify: true
 });
 
 var p3 = new CustomProject({
     id: "flutterHome",
     projectType: "custom",
     sourceLocale: "en-KR",
+    plugins: [ "ilib-loctool-webos-dart" ]
     }, "./testfiles", {
-    customProjectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {
@@ -85,9 +85,9 @@ var p4 = new CustomProject({
     sourceLocale: "en-KR",
     resourceDirs: {
         "json": "assets/i18n"
-        }
+    },
+    plugins: [ "ilib-loctool-webos-dart" ]
     }, "./testfiles", {
-    customProjectType: "webos-dart",
     dart: {
         "mappings": {
             "**/*.dart": {

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.test.js - test the JavaScript file handler object.
  *
- * Copyright (c) 2019-2024 JEDLSoft
+ * Copyright (c) 2019-2024, 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,35 +37,38 @@ function diff(a, b) {
 
 var p = new CustomProject({
     id: "webos-app",
-    projectType: "webos-web",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
     }
     }, "./testfiles", {
+    projectType: "webos-web",
     locales:["en-GB"]
 });
 
 var p2 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-web",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
     }
     }, "./testfiles", {
+    projectType: "webos-web",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
 
 var p3 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-c",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
     }
     }, "./testfiles", {
+    projectType: "webos-c",
     identify: true,
     resourceFileNames: {
       "c": "cstrings.json"
@@ -74,12 +77,13 @@ var p3 = new CustomProject({
 
 var p4 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-cpp",
+    projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "resources"
     }
     }, "./testfiles", {
+    projectType: "webos-cpp",
     identify: true,
     resourceFileNames: {
       "cpp": "cppstrings.json"
@@ -88,56 +92,19 @@ var p4 = new CustomProject({
 
 var p5 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-web",
-    sourceLocale: "en-US",
-    resourceDirs: {
-        "json": "resources"
-    }
-    }, "./testfiles", {
-    localeMap: {
-        "es-CO": "es"
-    }
-});
-
-var p6 = new CustomProject({
-    id: "flutterHome",
-    projectType: "webos-dart",
-    sourceLocale: "en-KR",
-    resourceDirs: {
-        "json": "assets/i18n"
-    }
-    }, "./testfiles", {
-    localeMap: {
-        "es-CO": "es"
-    },
-    dart: {
-        "mappings": {
-            "**/*.dart": {
-                "template": "[dir]/assets/i18n/[localeUnder].json"
-            }
-        }
-    }
-});
-
-// loctool 2.33.0 restricts the top-level projectType to a fixed whitelist, so webOS
-// projects declare projectType "custom" and preserve their real type in settings.projectType.
-// p7/p8 exercise that path (custom + settings.projectType) for cpp and dart.
-var p7 = new CustomProject({
-    id: "webosApp",
     projectType: "custom",
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "resources"
     }
     }, "./testfiles", {
-    identify: true,
-    projectType: "webos-cpp",
-    resourceFileNames: {
-      "cpp": "cppstrings.json"
+    projectType: "webos-web",
+    localeMap: {
+        "es-CO": "es"
     }
 });
 
-var p8 = new CustomProject({
+var p6 = new CustomProject({
     id: "flutterHome",
     projectType: "custom",
     sourceLocale: "en-KR",
@@ -461,32 +428,6 @@ describe("jsonresourcefilepath", function() {
             expect(jsrf.getResourceFilePath()).toBe(expected[i]);
         }
     });
-    test("JSONResourceFileGetResourceFilePathsCustomCpp", function() {
-        expect.assertions(15);
-        var jsrf;
-        var locales = ["en-US","en-GB", "en-AU", "es-CO",
-                    "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "hr-HR", "hr-ME", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
-
-        // projectType "custom" + settings.projectType "webos-cpp" must resolve
-        // the same cppstrings.json paths as a top-level "webos-cpp" project (p4).
-        var expected = [
-            "testfiles/resources/cppstrings.json","testfiles/resources/en/GB/cppstrings.json",
-            "testfiles/resources/en/AU/cppstrings.json","testfiles/resources/es/CO/cppstrings.json",
-            "testfiles/resources/es/cppstrings.json","testfiles/resources/et/cppstrings.json",
-            "testfiles/resources/fa/cppstrings.json","testfiles/resources/fa/AF/cppstrings.json",
-            "testfiles/resources/fr/cppstrings.json","testfiles/resources/fr/CA/cppstrings.json",
-            "testfiles/resources/hr/cppstrings.json", "testfiles/resources/hr/ME/cppstrings.json",
-            "testfiles/resources/zh/cppstrings.json","testfiles/resources/zh/Hant/HK/cppstrings.json",
-            "testfiles/resources/zh/Hant/TW/cppstrings.json"
-        ];
-        for (var i=0; i<locales.length;i++) {
-            jsrf = new JSONResourceFile({
-                project: p7,
-                locale: locales[i]
-            });
-            expect(jsrf.getResourceFilePath()).toBe(expected[i]);
-        }
-    });
     test("JSONResourceFileGetResourceFilePathsOverride", function() {
         expect.assertions(5);
         var jsrf;
@@ -561,28 +502,6 @@ describe("jsonresourcefilepath", function() {
         for (var i=0; i<locales.length;i++) {
             jsrf = new JSONResourceFile({
                 project: p6,
-                locale: locales[i]
-            });
-            expect(jsrf.getResourceFilePath()).toBe(expected[i]);
-        }
-    });
-    test("JSONResourceFileGetResourceFilePathsCustomFlutter", function() {
-        expect.assertions(5);
-        var jsrf;
-        var locales = ["en-GB", "de-DE", "de-AT", "es-CO", "es-ES"];
-
-        // projectType "custom" + settings.projectType "webos-dart" must resolve
-        // the same flat dart file paths as a top-level "webos-dart" project (p6).
-        var expected = [
-            "testfiles/assets/i18n/en_GB.json",
-            "testfiles/assets/i18n/de.json",
-            "testfiles/assets/i18n/de_AT.json",
-            "testfiles/assets/i18n/es.json",
-            "testfiles/assets/i18n/es_ES.json"
-        ];
-        for (var i=0; i<locales.length;i++) {
-            jsrf = new JSONResourceFile({
-                project: p8,
                 locale: locales[i]
             });
             expect(jsrf.getResourceFilePath()).toBe(expected[i]);

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
@@ -43,7 +43,7 @@ var p = new CustomProject({
         "json": "localized_json"
     }
     }, "./testfiles", {
-    projectType: "webos-web",
+    customProjectType: "webos-web",
     locales:["en-GB"]
 });
 
@@ -55,7 +55,7 @@ var p2 = new CustomProject({
         "json": "localized_json"
     }
     }, "./testfiles", {
-    projectType: "webos-web",
+    customProjectType: "webos-web",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
@@ -68,7 +68,7 @@ var p3 = new CustomProject({
         "json": "localized_json"
     }
     }, "./testfiles", {
-    projectType: "webos-c",
+    customProjectType: "webos-c",
     identify: true,
     resourceFileNames: {
       "c": "cstrings.json"
@@ -83,7 +83,7 @@ var p4 = new CustomProject({
         "json": "resources"
     }
     }, "./testfiles", {
-    projectType: "webos-cpp",
+    customProjectType: "webos-cpp",
     identify: true,
     resourceFileNames: {
       "cpp": "cppstrings.json"
@@ -98,7 +98,7 @@ var p5 = new CustomProject({
         "json": "resources"
     }
     }, "./testfiles", {
-    projectType: "webos-web",
+    customProjectType: "webos-web",
     localeMap: {
         "es-CO": "es"
     }
@@ -112,7 +112,7 @@ var p6 = new CustomProject({
         "json": "assets/i18n"
     }
     }, "./testfiles", {
-    projectType: "webos-dart",
+    customProjectType: "webos-dart",
     localeMap: {
         "es-CO": "es"
     },

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
@@ -41,9 +41,9 @@ var p = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-javascript" ]
     }, "./testfiles", {
-    customProjectType: "webos-web",
     locales:["en-GB"]
 });
 
@@ -53,9 +53,9 @@ var p2 = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-javascript" ]
     }, "./testfiles", {
-    customProjectType: "webos-web",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
@@ -66,9 +66,9 @@ var p3 = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "localized_json"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-c" ]
     }, "./testfiles", {
-    customProjectType: "webos-c",
     identify: true,
     resourceFileNames: {
       "c": "cstrings.json"
@@ -81,9 +81,9 @@ var p4 = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "resources"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-cpp" ]
     }, "./testfiles", {
-    customProjectType: "webos-cpp",
     identify: true,
     resourceFileNames: {
       "cpp": "cppstrings.json"
@@ -96,9 +96,9 @@ var p5 = new CustomProject({
     sourceLocale: "en-US",
     resourceDirs: {
         "json": "resources"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-javascript" ]
     }, "./testfiles", {
-    customProjectType: "webos-web",
     localeMap: {
         "es-CO": "es"
     }
@@ -110,9 +110,9 @@ var p6 = new CustomProject({
     sourceLocale: "en-KR",
     resourceDirs: {
         "json": "assets/i18n"
-    }
+    },
+    plugins: [ "ilib-loctool-webos-dart" ]
     }, "./testfiles", {
-    customProjectType: "webos-dart",
     localeMap: {
         "es-CO": "es"
     },

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFilePaths.test.js
@@ -119,6 +119,45 @@ var p6 = new CustomProject({
     }
 });
 
+// loctool 2.33.0 restricts the top-level projectType to a fixed whitelist, so webOS
+// projects declare projectType "custom" and preserve their real type in settings.projectType.
+// p7/p8 exercise that path (custom + settings.projectType) for cpp and dart.
+var p7 = new CustomProject({
+    id: "webosApp",
+    projectType: "custom",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "json": "resources"
+    }
+    }, "./testfiles", {
+    identify: true,
+    projectType: "webos-cpp",
+    resourceFileNames: {
+      "cpp": "cppstrings.json"
+    }
+});
+
+var p8 = new CustomProject({
+    id: "flutterHome",
+    projectType: "custom",
+    sourceLocale: "en-KR",
+    resourceDirs: {
+        "json": "assets/i18n"
+    }
+    }, "./testfiles", {
+    projectType: "webos-dart",
+    localeMap: {
+        "es-CO": "es"
+    },
+    dart: {
+        "mappings": {
+            "**/*.dart": {
+                "template": "[dir]/assets/i18n/[localeUnder].json"
+            }
+        }
+    }
+});
+
 describe("jsonresourcefilepath", function() {
     test("JSONResourceFileConstructor", function() {
         expect.assertions(1);
@@ -422,6 +461,32 @@ describe("jsonresourcefilepath", function() {
             expect(jsrf.getResourceFilePath()).toBe(expected[i]);
         }
     });
+    test("JSONResourceFileGetResourceFilePathsCustomCpp", function() {
+        expect.assertions(15);
+        var jsrf;
+        var locales = ["en-US","en-GB", "en-AU", "es-CO",
+                    "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "hr-HR", "hr-ME", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
+
+        // projectType "custom" + settings.projectType "webos-cpp" must resolve
+        // the same cppstrings.json paths as a top-level "webos-cpp" project (p4).
+        var expected = [
+            "testfiles/resources/cppstrings.json","testfiles/resources/en/GB/cppstrings.json",
+            "testfiles/resources/en/AU/cppstrings.json","testfiles/resources/es/CO/cppstrings.json",
+            "testfiles/resources/es/cppstrings.json","testfiles/resources/et/cppstrings.json",
+            "testfiles/resources/fa/cppstrings.json","testfiles/resources/fa/AF/cppstrings.json",
+            "testfiles/resources/fr/cppstrings.json","testfiles/resources/fr/CA/cppstrings.json",
+            "testfiles/resources/hr/cppstrings.json", "testfiles/resources/hr/ME/cppstrings.json",
+            "testfiles/resources/zh/cppstrings.json","testfiles/resources/zh/Hant/HK/cppstrings.json",
+            "testfiles/resources/zh/Hant/TW/cppstrings.json"
+        ];
+        for (var i=0; i<locales.length;i++) {
+            jsrf = new JSONResourceFile({
+                project: p7,
+                locale: locales[i]
+            });
+            expect(jsrf.getResourceFilePath()).toBe(expected[i]);
+        }
+    });
     test("JSONResourceFileGetResourceFilePathsOverride", function() {
         expect.assertions(5);
         var jsrf;
@@ -496,6 +561,28 @@ describe("jsonresourcefilepath", function() {
         for (var i=0; i<locales.length;i++) {
             jsrf = new JSONResourceFile({
                 project: p6,
+                locale: locales[i]
+            });
+            expect(jsrf.getResourceFilePath()).toBe(expected[i]);
+        }
+    });
+    test("JSONResourceFileGetResourceFilePathsCustomFlutter", function() {
+        expect.assertions(5);
+        var jsrf;
+        var locales = ["en-GB", "de-DE", "de-AT", "es-CO", "es-ES"];
+
+        // projectType "custom" + settings.projectType "webos-dart" must resolve
+        // the same flat dart file paths as a top-level "webos-dart" project (p6).
+        var expected = [
+            "testfiles/assets/i18n/en_GB.json",
+            "testfiles/assets/i18n/de.json",
+            "testfiles/assets/i18n/de_AT.json",
+            "testfiles/assets/i18n/es.json",
+            "testfiles/assets/i18n/es_ES.json"
+        ];
+        for (var i=0; i<locales.length;i++) {
+            jsrf = new JSONResourceFile({
+                project: p8,
                 locale: locales[i]
             });
             expect(jsrf.getResourceFilePath()).toBe(expected[i]);

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
@@ -27,7 +27,7 @@ if (!JSONResourceFileType) {
 }
 
 var p = new CustomProject({
-    sourceLocale: "en-US"
+    sourceLocale: "en-US",
 }, "./testfiles", {
     locales:["en-GB"]
 });
@@ -36,10 +36,10 @@ var p2 = new CustomProject({
     id: "webosApp",
     projectType: "custom",
     sourceLocale: "en-US",
+    plugins: [ "ilib-loctool-webos-javascript" ]
 },
 "./testfiles",
 {
-    customProjectType: "webos-web",
     targetDir: "custom_dir",
     locales: ["es-ES"],
 }

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFileType.test.js - test the HTML template file type handler object.
  *
- * Copyright (c) 2019-2021, 2023 JEDLSoft
+ * Copyright (c) 2019-2021, 2023, 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,12 @@ var p = new CustomProject({
 
 var p2 = new CustomProject({
     id: "webosApp",
-    projectType: "webos-web",
+    projectType: "custom",
     sourceLocale: "en-US",
 },
 "./testfiles",
 {
+    projectType: "webos-web",
     targetDir: "custom_dir",
     locales: ["es-ES"],
 }

--- a/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
+++ b/packages/ilib-loctool-webos-json-resource/test/JSONResourceFileType.test.js
@@ -39,7 +39,7 @@ var p2 = new CustomProject({
 },
 "./testfiles",
 {
-    projectType: "webos-web",
+    customProjectType: "webos-web",
     targetDir: "custom_dir",
     locales: ["es-ES"],
 }

--- a/packages/ilib-loctool-webos-json/package.json
+++ b/packages/ilib-loctool-webos-json/package.json
@@ -51,15 +51,15 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3",
+        "jest": "^30.4.2",
+        "loctool": "2.33.0",
         "ilib-loctool-webos-common": "workspace:*"
     }
 }

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -1,7 +1,7 @@
 /*
  * JsonAppinfoFile.test.js - test the appinfo.json file type handler object.
  *
- * Copyright (c) 2023, 2025 JEDLSoft
+ * Copyright (c) 2023, 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,14 @@ if (!JsonFile) {
 
 var p = new CustomProject({
     id: "app",
-    type: "webos-web",
+    type: "custom",
     sourceLocale: "en-KR",
     schema: "./test/testfiles/appinfo.schema.json",
     resourceDirs: {
         "json": "localized_json"
     },
     }, "./test/testfiles", {
+    projectType: "webos-web",
     locales:["en-GB", "ko-KR"],
     metadata: {
         "device-type": "Monitor"
@@ -257,7 +258,7 @@ describe("jsonfile", function() {
             "id": "app",
             "title": "Settings",
             "version": "4.0.1",
-            "type": "webos-web",
+            "type": "custom",
             "usePrerendering": true,
             "v8SnapshotFile": "snapshot_b"
         });
@@ -338,7 +339,7 @@ describe("jsonfile", function() {
             "id": "app",
             "title": "Photo &amp; Video",
             "version": "4.0.1",
-            "type": "webos-web",
+            "type": "custom",
             "usePrerendering": true,
             "v8SnapshotFile": "snapshot_b"
         });
@@ -476,7 +477,7 @@ describe("jsonfile", function() {
             "title": "Photo &amp; Video",
             "title@oled": "Photo &amp; Video@oled",
             "version": "4.0.1",
-            "type": "webos-web",
+            "type": "custom",
             "displayName": "PhoeoVideo",
             "usePrerendering": true,
             "v8SnapshotFile": "snapshot_b"

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -34,7 +34,6 @@ var p = new CustomProject({
         "json": "localized_json"
     },
     }, "./test/testfiles", {
-    customProjectType: "webos-web",
     locales:["en-GB", "ko-KR"],
     metadata: {
         "device-type": "Monitor"

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -34,7 +34,7 @@ var p = new CustomProject({
         "json": "localized_json"
     },
     }, "./test/testfiles", {
-    projectType: "webos-web",
+    customProjectType: "webos-web",
     locales:["en-GB", "ko-KR"],
     metadata: {
         "device-type": "Monitor"

--- a/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileAppinfo.test.js
@@ -307,7 +307,7 @@ describe("jsonfile", function() {
             "id": "app",
             "title": "Photo &amp; Video",
             "version": "4.0.1",
-            "type": "webos-web",
+            "type": "custom",
             "usePrerendering": true,
             "v8SnapshotFile": "snapshot_b"
         });

--- a/packages/ilib-loctool-webos-json/test/JsonFileQcardInfo.test.js
+++ b/packages/ilib-loctool-webos-json/test/JsonFileQcardInfo.test.js
@@ -27,7 +27,7 @@ if (!JsonFile) {
 
 var p = new CustomProject({
     id: "app",
-    type: "webos-web",
+    type: "custom",
     sourceLocale: "en-KR",
     schema: "./test/testfiles/qcardinfo.schema.json",
     resourceDirs: {

--- a/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
+++ b/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
@@ -41,7 +41,7 @@ describe('[integration] test the localization result of webos-json app', () => {
             plugins: [ "ilib-loctool-webos-json" ]
         };
         const appSettings = {
-            projectType: "webos-json",
+            customProjectType: "webos-json",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
+++ b/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
@@ -41,7 +41,6 @@ describe('[integration] test the localization result of webos-json app', () => {
             plugins: [ "ilib-loctool-webos-json" ]
         };
         const appSettings = {
-            customProjectType: "webos-json",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
+++ b/packages/ilib-loctool-webos-json/test/integrationTest/JsonApp.test.js
@@ -1,7 +1,7 @@
 /*
  * JsApp.test.js - test the localization result of webos-js app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ describe('[integration] test the localization result of webos-json app', () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-json",
-            projectType: "webos-json",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "resources" },
             pseudoLocale : {
@@ -41,6 +41,7 @@ describe('[integration] test the localization result of webos-json app', () => {
             plugins: [ "ilib-loctool-webos-json" ]
         };
         const appSettings = {
+            projectType: "webos-json",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-json/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-json/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     },
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-qml/package.json
+++ b/packages/ilib-loctool-webos-qml/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
@@ -64,7 +64,6 @@ describe('[integration] test the localization result of webos-qml app', () => {
         };
 
         const appSettings = {
-            customProjectType: "webos-qml",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
@@ -1,7 +1,7 @@
 /*
  * QmlApp.test.js - test the localization result of webos-qml app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ describe('[integration] test the localization result of webos-qml app', () => {
         const projectSettings = {
             rootDir: projectRoot,
             id: "sample-webos-qml",
-            projectType: "webos-qml",
+            projectType: "custom",
             sourceLocale: "en-KR",
             pseudoLocale : {
                 "zxx-XX": "debug"
@@ -64,6 +64,7 @@ describe('[integration] test the localization result of webos-qml app', () => {
         };
 
         const appSettings = {
+            projectType: "webos-qml",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/QmlApp.test.js
@@ -64,7 +64,7 @@ describe('[integration] test the localization result of webos-qml app', () => {
         };
 
         const appSettings = {
-            projectType: "webos-qml",
+            customProjectType: "webos-qml",
             localizeOnly: true,
             translationsDir : ["./xliffs", "./common"],
             mode: "localize",

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/package.json
@@ -13,10 +13,10 @@
     "dependencies": {
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-ts-resource/package.json
+++ b/packages/ilib-loctool-webos-ts-resource/package.json
@@ -53,15 +53,15 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "pretty-data": "^0.40.0",
         "xml-js": "^1.6.11"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.0"
     }
 }

--- a/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
+++ b/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
@@ -31,7 +31,6 @@ var p = new CustomProject({
         "ts": "."
         }
     }, ".", {
-        customProjectType: "webos-qml",
         locales:["en-GB"]
     });
 
@@ -43,7 +42,6 @@ var p2 = new CustomProject({
         "ts": "locales"
         }
     }, "./testfiles", {
-    customProjectType: "webos-qml",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
@@ -56,7 +54,6 @@ var p3 = new CustomProject({
         "ts": "locales"
         }
     }, "./testfiles", {
-    customProjectType: "webos-qml",
     locales:["es-CO", "es-ES", "fr-CA","fr-FR"],
     localeMap: {
         "es-CO":"es",

--- a/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
+++ b/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
@@ -31,7 +31,7 @@ var p = new CustomProject({
         "ts": "."
         }
     }, ".", {
-        projectType: "webos-qml",
+        customProjectType: "webos-qml",
         locales:["en-GB"]
     });
 
@@ -43,7 +43,7 @@ var p2 = new CustomProject({
         "ts": "locales"
         }
     }, "./testfiles", {
-    projectType: "webos-qml",
+    customProjectType: "webos-qml",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
@@ -56,7 +56,7 @@ var p3 = new CustomProject({
         "ts": "locales"
         }
     }, "./testfiles", {
-    projectType: "webos-qml",
+    customProjectType: "webos-qml",
     locales:["es-CO", "es-ES", "fr-CA","fr-FR"],
     localeMap: {
         "es-CO":"es",

--- a/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
+++ b/packages/ilib-loctool-webos-ts-resource/test/TSResourceFile.test.js
@@ -1,7 +1,7 @@
 /*
  * TSResourceFile.test.js - test the ts file handler object.
  *
- * Copyright (c) 2020-2023, JEDLSoft
+ * Copyright (c) 2020-2023, 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,35 +25,38 @@ if (!TSResourceFile) {
 
 var p = new CustomProject({
     id: "inputcommon",
-    projectType: "webos-qml",
+    projectType: "custom",
     sourceLocale: "en-KR",
     resourceDirs: {
         "ts": "."
         }
     }, ".", {
+        projectType: "webos-qml",
         locales:["en-GB"]
     });
 
 var p2 = new CustomProject({
     id: "quicksettings",
-    projectType: "webos-qml",
+    projectType: "custom",
     sourceLocale: "en-KR",
     resourceDirs: {
         "ts": "locales"
         }
     }, "./testfiles", {
+    projectType: "webos-qml",
     locales:["en-GB", "de-DE", "de-AT"],
     identify: true
 });
 
 var p3 = new CustomProject({
     id: "quicksettings",
-    projectType: "webos-qml",
+    projectType: "custom",
     sourceLocale: "en-KR",
     resourceDirs: {
         "ts": "locales"
         }
     }, "./testfiles", {
+    projectType: "webos-qml",
     locales:["es-CO", "es-ES", "fr-CA","fr-FR"],
     localeMap: {
         "es-CO":"es",

--- a/packages/ilib-xliff-webos/package.json
+++ b/packages/ilib-xliff-webos/package.json
@@ -61,7 +61,7 @@
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-babel": "^8.0.0",
         "grunt": "^1.6.2",
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     },
     "dependencies": {
         "ilib-common": "^1.1.7",

--- a/packages/samples-lint/package.json
+++ b/packages/samples-lint/package.json
@@ -49,10 +49,10 @@
         "test-snapshot-update": "pnpm test:jest -u"
     },
     "dependencies": {
-        "ilib-lint": "^2.21.2",
+        "ilib-lint": "^2.21.5",
         "ilib-lint-webos": "workspace:*",
         "xml-js": "^1.6.11",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "cheerio": "^1.2.0"
     }
 }

--- a/packages/samples-loctool/webos-c/package.json
+++ b/packages/samples-loctool/webos-c/package.json
@@ -20,9 +20,9 @@
         "ilib-loctool-webos-c": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-c/project.json
+++ b/packages/samples-loctool/webos-c/project.json
@@ -26,7 +26,7 @@
         "resources"
     ],
     "settings": {
-        "projectType": "webos-c",
+        "customProjectType": "webos-c",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-c/project.json
+++ b/packages/samples-loctool/webos-c/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample-webos-c",
     "id": "sample-webos-c",
-    "projectType": "webos-c",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale": {
         "zxx-XX": "debug",
@@ -26,6 +26,7 @@
         "resources"
     ],
     "settings": {
+        "projectType": "webos-c",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-c/project.json
+++ b/packages/samples-loctool/webos-c/project.json
@@ -26,7 +26,6 @@
         "resources"
     ],
     "settings": {
-        "customProjectType": "webos-c",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-cpp/package.json
+++ b/packages/samples-loctool/webos-cpp/package.json
@@ -20,9 +20,9 @@
         "ilib-loctool-webos-cpp": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-cpp/project.json
+++ b/packages/samples-loctool/webos-cpp/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample-webos-cpp",
     "id": "sample-webos-cpp",
-    "projectType": "webos-cpp",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale":  {
         "zxx-XX": "debug",
@@ -26,6 +26,7 @@
         "resources"
     ],
     "settings": {
+        "projectType": "webos-cpp",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-cpp/project.json
+++ b/packages/samples-loctool/webos-cpp/project.json
@@ -26,7 +26,7 @@
         "resources"
     ],
     "settings": {
-        "projectType": "webos-cpp",
+        "customProjectType": "webos-cpp",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-cpp/project.json
+++ b/packages/samples-loctool/webos-cpp/project.json
@@ -26,7 +26,6 @@
         "resources"
     ],
     "settings": {
-        "customProjectType": "webos-cpp",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -21,9 +21,9 @@
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -8,8 +8,8 @@
     "scripts": {
         "loc": "loctool -2 --xliffStyle webOS --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle webOS --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
-        "loc-generate": "loctool generate -2 --translations xliffs --xliffStyle webOS --projectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
-        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "loc-generate": "loctool generate -2 --translations xliffs --xliffStyle webOS --projectType custom --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType custom --customProjectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "clean": "rm -rf *.xliff assets assets2 resources",
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -9,7 +9,7 @@
         "loc": "loctool -2 --xliffStyle webOS --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle webOS --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "loc-generate": "loctool generate -2 --translations xliffs --xliffStyle webOS --projectType custom --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
-        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType custom --customProjectType webos-dart --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType custom --projectId sample-webos-dart --sourceLocale en-KR --resourceDirs json=assets/i18n --resourceFileTypes json=webos-json-resource --plugins webos-dart,webos-json -l en-US,es-CO,es-ES,fr-CA,fr-FR,ja-JP,ko-KR,sl-SI --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
         "clean": "rm -rf *.xliff assets assets2 resources",
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",

--- a/packages/samples-loctool/webos-dart/project.json
+++ b/packages/samples-loctool/webos-dart/project.json
@@ -29,7 +29,7 @@
         "assets"
     ],
     "settings": {
-        "projectType": "webos-dart",
+        "customProjectType": "webos-dart",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-dart/project.json
+++ b/packages/samples-loctool/webos-dart/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample-webos-dart",
     "id": "sample-webos-dart",
-    "projectType": "webos-dart",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale":  {
         "zxx-XX": "debug",
@@ -29,6 +29,7 @@
         "assets"
     ],
     "settings": {
+        "projectType": "webos-dart",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-dart/project.json
+++ b/packages/samples-loctool/webos-dart/project.json
@@ -11,7 +11,7 @@
         "as-XX" : "debug-font"
     },
     "resourceDirs": {
-        "json": "resources"
+        "json": "assets/i18n"
     },
     "resourceFileTypes": {
         "json":"ilib-loctool-webos-json-resource"
@@ -29,7 +29,6 @@
         "assets"
     ],
     "settings": {
-        "customProjectType": "webos-dart",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-US",

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -36,13 +36,14 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
         const projectSettings = {
             rootDir: ".",
             id: "sample-webos-dart",
-            projectType: "webos-dart",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "assets2/i18n" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
             plugins: [ "ilib-loctool-webos-dart" ]
         };
         const appSettings = {
+            customProjectType: "webos-dart",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             xliffVersion: 2,

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -43,7 +43,6 @@ describe('test the localization result (generate mode) of webos-dart app', () =>
             plugins: [ "ilib-loctool-webos-dart" ]
         };
         const appSettings = {
-            customProjectType: "webos-dart",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             xliffVersion: 2,

--- a/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
+++ b/packages/samples-loctool/webos-dart/test/DartAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * DartAppGenerate.test.js - test the localization result in generate mode of webos-dart app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -21,10 +21,10 @@
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "ilib": "^14.21.3",
-        "jest": "^30.3.0"
+        "ilib": "^14.22.0",
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -10,7 +10,7 @@
         "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle webOS --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
         "clean": "rm -rf *.xliff resources resources2",
         "loc-generate": "loctool generate -2 --translations xliffs --xliffStyle webOS --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json  --projectId sample-webos-js -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
-        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType webos-js --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
         "coverage": "pnpm test --coverage",
         "test": "pnpm test:jest",
         "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",

--- a/packages/samples-loctool/webos-js/project.json
+++ b/packages/samples-loctool/webos-js/project.json
@@ -27,7 +27,7 @@
         "common"
     ],
     "settings": {
-        "projectType": "webos-js",
+        "customProjectType": "webos-js",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/packages/samples-loctool/webos-js/project.json
+++ b/packages/samples-loctool/webos-js/project.json
@@ -27,7 +27,6 @@
         "common"
     ],
     "settings": {
-        "customProjectType": "webos-js",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/packages/samples-loctool/webos-js/project.json
+++ b/packages/samples-loctool/webos-js/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample-webos-js",
     "id": "sample-webos-js",
-    "projectType": "webos-js",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale":  {
         "zxx-XX": "debug",
@@ -27,6 +27,7 @@
         "common"
     ],
     "settings": {
+        "projectType": "webos-js",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * JsAppGenerate.test.js - test the localization result in generate mode of webos-js app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -42,7 +42,6 @@ describe('test the localization result (generate mode) of webos-js app', () => {
             plugins: [ "ilib-loctool-webos-javascript" ]
         };
         const appSettings = {
-            customProjectType: "webos-js",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             xliffVersion: 2,

--- a/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js/test/JsAppGenerate.test.js
@@ -35,13 +35,14 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         const projectSettings = {
             rootDir: ".",
             id: "sample-webos-js",
-            projectType: "webos-js",
+            projectType: "custom",
             sourceLocale: "en-KR",
             resourceDirs : { "json": "resources2" },
             resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
             plugins: [ "ilib-loctool-webos-javascript" ]
         };
         const appSettings = {
+            customProjectType: "webos-js",
             translationsDir: "./xliffs",
             xliffStyle: "webOS",
             xliffVersion: 2,

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -18,9 +18,9 @@
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.0"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-json/project.json
+++ b/packages/samples-loctool/webos-json/project.json
@@ -23,7 +23,7 @@
         "subDirCase"
     ],
     "settings": {
-        "projectType": "webos-json",
+        "customProjectType": "webos-json",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-json/project.json
+++ b/packages/samples-loctool/webos-json/project.json
@@ -1,7 +1,7 @@
 {
     "name": "sample-webos-json",
     "id": "sample-webos-json",
-    "projectType": "webos-json",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale":  {
         "zxx-XX": "debug",
@@ -23,6 +23,7 @@
         "subDirCase"
     ],
     "settings": {
+        "projectType": "webos-json",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-json/project.json
+++ b/packages/samples-loctool/webos-json/project.json
@@ -19,11 +19,12 @@
         ".*",
         "xliffs",
         "resources",
+        "**/resources",
+        "**/resources/**",
         "common",
         "subDirCase"
     ],
     "settings": {
-        "customProjectType": "webos-json",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-AU",

--- a/packages/samples-loctool/webos-json/subDirCase/package.json
+++ b/packages/samples-loctool/webos-json/subDirCase/package.json
@@ -13,10 +13,10 @@
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.0",
         "micromatch": "^4.0.8"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-json/subDirCase/project.json
+++ b/packages/samples-loctool/webos-json/subDirCase/project.json
@@ -19,10 +19,11 @@
         ".*",
         "xliffs",
         "resources",
+        "**/resources",
+        "**/resources/**",
         "common"
     ],
     "settings": {
-        "customProjectType": "webos-json",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-GB",

--- a/packages/samples-loctool/webos-json/subDirCase/project.json
+++ b/packages/samples-loctool/webos-json/subDirCase/project.json
@@ -22,6 +22,7 @@
         "common"
     ],
     "settings": {
+        "customProjectType": "webos-json",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "en-GB",

--- a/packages/samples-loctool/webos-qml/package.json
+++ b/packages/samples-loctool/webos-qml/package.json
@@ -19,10 +19,10 @@
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-qml/project.json
+++ b/packages/samples-loctool/webos-qml/project.json
@@ -26,7 +26,6 @@
         "resources"
     ],
     "settings": {
-        "customProjectType": "webos-qml",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/packages/samples-loctool/webos-qml/project.json
+++ b/packages/samples-loctool/webos-qml/project.json
@@ -26,7 +26,7 @@
         "resources"
     ],
     "settings": {
-        "projectType": "webos-qml",
+        "customProjectType": "webos-qml",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/packages/samples-loctool/webos-qml/project.json
+++ b/packages/samples-loctool/webos-qml/project.json
@@ -1,7 +1,7 @@
 {
     "name": "music",
     "id": "music",
-    "projectType": "webos-qml",
+    "projectType": "custom",
     "sourceLocale": "en-KR",
     "pseudoLocale":  {
         "zxx-XX": "debug",
@@ -26,6 +26,7 @@
         "resources"
     ],
     "settings": {
+        "projectType": "webos-qml",
         "translationsDir": ["./xliffs", "./common"],
         "locales":[
             "as-IN",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.5
         version: 4.0.5
@@ -56,11 +56,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-c/test/integrationTest:
     dependencies:
@@ -71,29 +71,29 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-common:
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-common/test/ilib-loctool-mock: {}
 
   packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
 
   packages/ilib-loctool-webos-cpp:
     dependencies:
@@ -105,11 +105,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-cpp/test/integrationTest:
     dependencies:
@@ -120,18 +120,18 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-dart:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       ilib-loctool-webos-common:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-common
@@ -143,11 +143,11 @@ importers:
         version: 4.0.8
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-dart/test/integrationTest:
     dependencies:
@@ -158,12 +158,12 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-dist:
     dependencies:
@@ -192,8 +192,8 @@ importers:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-javascript:
     dependencies:
@@ -205,11 +205,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-javascript/test/integrationTest:
     dependencies:
@@ -220,21 +220,21 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-json:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -243,24 +243,24 @@ importers:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-common
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-json-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-json/test/integrationTest:
     dependencies:
@@ -268,12 +268,12 @@ importers:
         specifier: workspace:*
         version: link:../..
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-qml:
     dependencies:
@@ -285,11 +285,11 @@ importers:
         version: link:../ilib-loctool-webos-ts-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-loctool-webos-qml/test/integrationTest:
     dependencies:
@@ -300,21 +300,21 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-ts-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       pretty-data:
         specifier: ^0.40.0
         version: 0.40.0
@@ -323,11 +323,11 @@ importers:
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.0
+        version: 2.33.0
 
   packages/ilib-xliff-webos:
     dependencies:
@@ -343,7 +343,7 @@ importers:
         version: 7.29.0
       '@babel/preset-env':
         specifier: ^7.29.2
-        version: 7.29.2(@babel/core@7.29.0)
+        version: 7.29.7(@babel/core@7.29.0)
       babel-plugin-add-module-exports:
         specifier: ^1.0.4
         version: 1.0.4
@@ -357,13 +357,11 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       load-grunt-tasks:
         specifier: ^5.1.0
         version: 5.1.0(grunt@1.6.2)
-
-  packages/ilib-xliff-webos/lib: {}
 
   packages/ilib-xliff-webos/src: {}
 
@@ -375,14 +373,14 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       ilib-lint:
-        specifier: ^2.21.2
-        version: 2.21.2
+        specifier: ^2.21.5
+        version: 2.21.5
       ilib-lint-webos:
         specifier: workspace:*
         version: link:../ilib-lint-webos
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -401,12 +399,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-cpp:
     dependencies:
@@ -420,12 +418,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-dart:
     dependencies:
@@ -442,12 +440,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-js:
     dependencies:
@@ -464,15 +462,15 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-json:
     dependencies:
@@ -483,12 +481,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-json/subDirCase:
     dependencies:
@@ -499,15 +497,15 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-qml:
     dependencies:
@@ -524,64 +522,66 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.0
+        version: 2.33.0
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
 packages:
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.28.6':
-    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1':
-    resolution: {integrity: sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-create-regexp-features-plugin@7.28.5':
-    resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
+  '@babel/helper-create-regexp-features-plugin@7.29.7':
+    resolution: {integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -595,27 +595,21 @@ packages:
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-member-expression-to-functions@7.27.1':
-    resolution: {integrity: sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
-    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
@@ -623,42 +617,46 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.27.1':
-    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.28.6':
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-remap-async-to-generator@7.27.1':
-    resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-remap-async-to-generator@7.29.7':
+    resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.27.1':
-    resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.28.6':
-    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
@@ -669,12 +667,20 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-wrap-function@7.28.3':
-    resolution: {integrity: sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-wrap-function@7.29.7':
+    resolution: {integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.2':
@@ -686,42 +692,48 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
-    resolution: {integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7':
+    resolution: {integrity: sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1':
-    resolution: {integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==}
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7':
+    resolution: {integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
-    resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7':
+    resolution: {integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1':
-    resolution: {integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==}
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7':
+    resolution: {integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7':
+    resolution: {integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6':
-    resolution: {integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==}
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7':
+    resolution: {integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -753,20 +765,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-import-assertions@7.28.6':
-    resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
+  '@babel/plugin-syntax-import-assertions@7.29.7':
+    resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-import-attributes@7.28.6':
     resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.29.7':
+    resolution: {integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -841,314 +853,314 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-transform-arrow-functions@7.27.1':
-    resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
+  '@babel/plugin-transform-arrow-functions@7.29.7':
+    resolution: {integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0':
-    resolution: {integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==}
+  '@babel/plugin-transform-async-generator-functions@7.29.7':
+    resolution: {integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-to-generator@7.28.6':
-    resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
+  '@babel/plugin-transform-async-to-generator@7.29.7':
+    resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1':
-    resolution: {integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==}
+  '@babel/plugin-transform-block-scoped-functions@7.29.7':
+    resolution: {integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoping@7.28.6':
-    resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
+  '@babel/plugin-transform-block-scoping@7.29.7':
+    resolution: {integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-properties@7.28.6':
-    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
+  '@babel/plugin-transform-class-properties@7.29.7':
+    resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-static-block@7.28.6':
-    resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
+  '@babel/plugin-transform-class-static-block@7.29.7':
+    resolution: {integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
 
-  '@babel/plugin-transform-classes@7.28.6':
-    resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
+  '@babel/plugin-transform-classes@7.29.7':
+    resolution: {integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-computed-properties@7.28.6':
-    resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
+  '@babel/plugin-transform-computed-properties@7.29.7':
+    resolution: {integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-destructuring@7.28.5':
-    resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
+  '@babel/plugin-transform-destructuring@7.29.7':
+    resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-dotall-regex@7.28.6':
-    resolution: {integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==}
+  '@babel/plugin-transform-dotall-regex@7.29.7':
+    resolution: {integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1':
-    resolution: {integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==}
+  '@babel/plugin-transform-duplicate-keys@7.29.7':
+    resolution: {integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0':
-    resolution: {integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==}
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7':
+    resolution: {integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-transform-dynamic-import@7.27.1':
-    resolution: {integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==}
+  '@babel/plugin-transform-dynamic-import@7.29.7':
+    resolution: {integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6':
-    resolution: {integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==}
+  '@babel/plugin-transform-explicit-resource-management@7.29.7':
+    resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6':
-    resolution: {integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==}
+  '@babel/plugin-transform-exponentiation-operator@7.29.7':
+    resolution: {integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1':
-    resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
+  '@babel/plugin-transform-export-namespace-from@7.29.7':
+    resolution: {integrity: sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-for-of@7.27.1':
-    resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
+  '@babel/plugin-transform-for-of@7.29.7':
+    resolution: {integrity: sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-function-name@7.27.1':
-    resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
+  '@babel/plugin-transform-function-name@7.29.7':
+    resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-json-strings@7.28.6':
-    resolution: {integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==}
+  '@babel/plugin-transform-json-strings@7.29.7':
+    resolution: {integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-literals@7.27.1':
-    resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
+  '@babel/plugin-transform-literals@7.29.7':
+    resolution: {integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6':
-    resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7':
+    resolution: {integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1':
-    resolution: {integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==}
+  '@babel/plugin-transform-member-expression-literals@7.29.7':
+    resolution: {integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-amd@7.27.1':
-    resolution: {integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==}
+  '@babel/plugin-transform-modules-amd@7.29.7':
+    resolution: {integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+  '@babel/plugin-transform-modules-commonjs@7.29.7':
+    resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.7':
+    resolution: {integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-umd@7.27.1':
-    resolution: {integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==}
+  '@babel/plugin-transform-modules-umd@7.29.7':
+    resolution: {integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
-    resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
+    resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-transform-new-target@7.27.1':
-    resolution: {integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==}
+  '@babel/plugin-transform-new-target@7.29.7':
+    resolution: {integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
-    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
+    resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-numeric-separator@7.28.6':
-    resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
+  '@babel/plugin-transform-numeric-separator@7.29.7':
+    resolution: {integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6':
-    resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
+  '@babel/plugin-transform-object-rest-spread@7.29.7':
+    resolution: {integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-super@7.27.1':
-    resolution: {integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==}
+  '@babel/plugin-transform-object-super@7.29.7':
+    resolution: {integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6':
-    resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
+  '@babel/plugin-transform-optional-catch-binding@7.29.7':
+    resolution: {integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-chaining@7.28.6':
-    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
+  '@babel/plugin-transform-optional-chaining@7.29.7':
+    resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-parameters@7.27.7':
-    resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
+  '@babel/plugin-transform-parameters@7.29.7':
+    resolution: {integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-methods@7.28.6':
-    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
+  '@babel/plugin-transform-private-methods@7.29.7':
+    resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6':
-    resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
+  '@babel/plugin-transform-private-property-in-object@7.29.7':
+    resolution: {integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-property-literals@7.27.1':
-    resolution: {integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==}
+  '@babel/plugin-transform-property-literals@7.29.7':
+    resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.29.0':
-    resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
+  '@babel/plugin-transform-regenerator@7.29.7':
+    resolution: {integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6':
-    resolution: {integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==}
+  '@babel/plugin-transform-regexp-modifiers@7.29.7':
+    resolution: {integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-transform-reserved-words@7.27.1':
-    resolution: {integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==}
+  '@babel/plugin-transform-reserved-words@7.29.7':
+    resolution: {integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1':
-    resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
+  '@babel/plugin-transform-shorthand-properties@7.29.7':
+    resolution: {integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-spread@7.28.6':
-    resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
+  '@babel/plugin-transform-spread@7.29.7':
+    resolution: {integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-sticky-regex@7.27.1':
-    resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
+  '@babel/plugin-transform-sticky-regex@7.29.7':
+    resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-template-literals@7.27.1':
-    resolution: {integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==}
+  '@babel/plugin-transform-template-literals@7.29.7':
+    resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1':
-    resolution: {integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==}
+  '@babel/plugin-transform-typeof-symbol@7.29.7':
+    resolution: {integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1':
-    resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
+  '@babel/plugin-transform-unicode-escapes@7.29.7':
+    resolution: {integrity: sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6':
-    resolution: {integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==}
+  '@babel/plugin-transform-unicode-property-regex@7.29.7':
+    resolution: {integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-regex@7.27.1':
-    resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
+  '@babel/plugin-transform-unicode-regex@7.29.7':
+    resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6':
-    resolution: {integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==}
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7':
+    resolution: {integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
+  '@babel/preset-env@7.29.7':
+    resolution: {integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1162,32 +1174,32 @@ packages:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1322,12 +1334,12 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jest/console@30.3.0':
-    resolution: {integrity: sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==}
+  '@jest/console@30.4.1':
+    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/core@30.3.0':
-    resolution: {integrity: sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==}
+  '@jest/core@30.4.2':
+    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1335,40 +1347,40 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/diff-sequences@30.3.0':
-    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/environment@30.3.0':
-    resolution: {integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==}
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect-utils@30.3.0':
-    resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect@30.3.0':
-    resolution: {integrity: sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==}
+  '@jest/expect@30.4.1':
+    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/fake-timers@30.3.0':
-    resolution: {integrity: sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==}
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/get-type@30.1.0':
     resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/globals@30.3.0':
-    resolution: {integrity: sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==}
+  '@jest/globals@30.4.1':
+    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/pattern@30.0.1':
-    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/reporters@30.3.0':
-    resolution: {integrity: sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==}
+  '@jest/reporters@30.4.1':
+    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1376,32 +1388,32 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/snapshot-utils@30.3.0':
-    resolution: {integrity: sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==}
+  '@jest/snapshot-utils@30.4.1':
+    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/source-map@30.0.1':
     resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-result@30.3.0':
-    resolution: {integrity: sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==}
+  '@jest/test-result@30.4.1':
+    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-sequencer@30.3.0':
-    resolution: {integrity: sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==}
+  '@jest/test-sequencer@30.4.1':
+    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/transform@30.3.0':
-    resolution: {integrity: sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==}
+  '@jest/transform@30.4.1':
+    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/types@30.3.0':
-    resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1462,8 +1474,8 @@ packages:
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
-  '@sinonjs/fake-timers@15.3.0':
-    resolution: {integrity: sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==}
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -1527,6 +1539,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.7.13':
     resolution: {integrity: sha512-LIKeCzNSkTWwGHjtiUIfvS96+7kpuyrKq2pzw/0XT2S8ykczj40Hh27oLTbXguCX8tGrCoaD2yXxzwqMMhAzhA==}
@@ -1705,8 +1718,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  babel-jest@30.3.0:
-    resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
+  babel-jest@30.4.1:
+    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-0
@@ -1718,8 +1731,8 @@ packages:
     resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
     engines: {node: '>=12'}
 
-  babel-plugin-jest-hoist@30.3.0:
-    resolution: {integrity: sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==}
+  babel-plugin-jest-hoist@30.4.0:
+    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-plugin-polyfill-corejs2@0.4.17:
@@ -1742,8 +1755,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
 
-  babel-preset-jest@30.3.0:
-    resolution: {integrity: sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==}
+  babel-preset-jest@30.4.0:
+    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
@@ -1782,11 +1795,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.25.4:
-    resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1836,9 +1844,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001739:
-    resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
 
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
@@ -2012,15 +2017,6 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2107,9 +2103,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  electron-to-chromium@1.5.211:
-    resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
@@ -2216,8 +2209,8 @@ packages:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
 
-  expect@30.3.0:
-    resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   extend@3.0.2:
@@ -2565,9 +2558,6 @@ packages:
   ilib-ctype@1.3.0:
     resolution: {integrity: sha512-NiEnz7/aSwCws1PDuYQi4m4AITrhGOeFqd6Tfvnc85wLyRZUVuOlVs5RFCA5rDSN0wdlzW25BT/NBG5kzV+Ggw==}
 
-  ilib-env@1.4.1:
-    resolution: {integrity: sha512-lhXj5AaOT6AAft3eSFTqncNSYhqMdXAq9RpAeCral1tJpZDmzxhxpnKcFghgbjk9NkFFBRxFxTIAkgSq9NfEfQ==}
-
   ilib-env@1.4.2:
     resolution: {integrity: sha512-H/nFk+qnC6hfgD6bgaSF+mohZUWqtfjQmStBCU3c832vv00Vtco6GrOSGaXwdr3QgnhzxL8zhLOUTtSTJ2gHxA==}
 
@@ -2578,8 +2568,8 @@ packages:
     resolution: {integrity: sha512-N9kB+DRhByIJROv0QcFz3NogNSjs61wu7hXrysz7H2gpAnYvZU/2RGxlCMC4vDm5tiQnHM5N1QKpmKhy/tVJhQ==}
     engines: {node: '>=12 <23'}
 
-  ilib-lint@2.21.2:
-    resolution: {integrity: sha512-Hjw3b/O5wx9SFlsXuM8sG00BsQLYy+9d/2nlbgUIHzWZ/oTqzqW2Bdto5FY5swhAt6ewtoC6Wj9gHgiOKoiEhQ==}
+  ilib-lint@2.21.5:
+    resolution: {integrity: sha512-pNQp5PrIGsAspdcdbv3hdtUjIL+w7lfWik6hnpvze/INAqHjchQJjQNTaT9LttphYEOBEGP3NJIlWV4D7Bup2g==}
     engines: {node: '>=12 <23'}
     hasBin: true
 
@@ -2596,22 +2586,23 @@ packages:
   ilib-localeinfo@1.1.0:
     resolution: {integrity: sha512-F77DV01lWANKqEw1QxEqYNO3Jj3H30kkYMGinMWoCIF18Kb/Gc/aJaaENWlS9kfZkbvfXthcBL7kuswMY+Hjdg==}
 
-  ilib-localematcher@1.3.1:
-    resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
-
   ilib-localematcher@1.3.2:
     resolution: {integrity: sha512-v+2rT11WOMlDQesseIYm4Kb9L6072SqLU7oObY3wPDh51Cr3s25bI8YEX+5VUT/YEN1e7h3bUslWt6huzlv62g==}
     engines: {node: '>=12 <23'}
 
-  ilib-po@1.1.4:
-    resolution: {integrity: sha512-YHea8MT1dF3lhb5vIYtL0eobjXWaEO29+wesWbYozsjMQZemf+gl6ehg0fNkWTnRKMC/b0kGpwM6KaTkuyOKrw==}
+  ilib-localematcher@1.3.4:
+    resolution: {integrity: sha512-UildyR0Dj8HeqN6/I7NwPoOoY0yX9NSlWlTA/PLrC4qozmcHbWkal7KPvcUjriSQfvpivHj/R0qx2TxbRXWkFg==}
+    engines: {node: '>=14 <23'}
+
+  ilib-po@1.1.5:
+    resolution: {integrity: sha512-MLm6Dh2+h/IVAIHuKgW54HoktOfAZOvTx6DldNxUkSRN6LbRFg83pw2S1wDLCykRWX6fvzBoIA0wqHYy81jl+w==}
     engines: {node: '>=12 <23'}
 
   ilib-scriptinfo@1.0.0:
     resolution: {integrity: sha512-GlMitfrpa5/27wxr3leG7Bri6GVD1yWBNAGyAOi0TWxjq/Zuo9n8CLYem4XIkqlCpUXbo5phPGZXCR2fWo39ig==}
 
-  ilib-tools-common@1.21.3:
-    resolution: {integrity: sha512-9GwF/DhD0W1HnccH/lWiEMkFz54mRSbfwrAKuLq3WcMn+XmJIU3qEUfq/6zgR7Nf8MjcMKGlFXkEvsFDTd21CA==}
+  ilib-tools-common@1.22.0:
+    resolution: {integrity: sha512-vTa3Z4WTt+clr/f/o2sZNjaYQuEosDiKNza+8zP0QbUojsugm4RprdsqNn8bgk2d1j/LIgqq1slwR+MZ5XIxcg==}
     engines: {node: '>=12 <23'}
 
   ilib-tree-node@2.0.1:
@@ -2627,8 +2618,8 @@ packages:
     resolution: {integrity: sha512-u2Uitc6238fQzIpwHx7qTt0GDii6ncBKtbLX6lvg67+x2iyQ4tz3nycyXg+c8wdaaVgqVGeBNs48uYGEKVJzkA==}
     hasBin: true
 
-  ilib@14.21.3:
-    resolution: {integrity: sha512-HQA76PAVwsjRxVUI7SzYaes4lOSEFkbED/klnWm/y3uOrLIJh1vZgMIlRp71AGq/rOQDdbtiF51hkxcnEHePlQ==}
+  ilib@14.22.0:
+    resolution: {integrity: sha512-N3Rj+B1BwVPjhl5z67lKfTepGYos9Yfx5dosRDnh5pmVKv69eHYXyN5MG2yv3FRS9ilygSE8DEC7fm6Yleng6A==}
     engines: {node: '>=8 <25'}
 
   import-local@3.2.0:
@@ -2895,16 +2886,16 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jest-changed-files@30.3.0:
-    resolution: {integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==}
+  jest-changed-files@30.4.1:
+    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-circus@30.3.0:
-    resolution: {integrity: sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==}
+  jest-circus@30.4.2:
+    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-cli@30.3.0:
-    resolution: {integrity: sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==}
+  jest-cli@30.4.2:
+    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -2913,8 +2904,8 @@ packages:
       node-notifier:
         optional: true
 
-  jest-config@30.3.0:
-    resolution: {integrity: sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==}
+  jest-config@30.4.2:
+    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -2928,40 +2919,40 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.3.0:
-    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-docblock@30.2.0:
-    resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
+  jest-docblock@30.4.0:
+    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-each@30.3.0:
-    resolution: {integrity: sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==}
+  jest-each@30.4.1:
+    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-environment-node@30.3.0:
-    resolution: {integrity: sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==}
+  jest-environment-node@30.4.1:
+    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-haste-map@30.3.0:
-    resolution: {integrity: sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==}
+  jest-haste-map@30.4.1:
+    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-leak-detector@30.3.0:
-    resolution: {integrity: sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==}
+  jest-leak-detector@30.4.1:
+    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.3.0:
-    resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.3.0:
-    resolution: {integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==}
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-mock@30.3.0:
-    resolution: {integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==}
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -2973,48 +2964,48 @@ packages:
       jest-resolve:
         optional: true
 
-  jest-regex-util@30.0.1:
-    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve-dependencies@30.3.0:
-    resolution: {integrity: sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==}
+  jest-resolve-dependencies@30.4.2:
+    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve@30.3.0:
-    resolution: {integrity: sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==}
+  jest-resolve@30.4.1:
+    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runner@30.3.0:
-    resolution: {integrity: sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==}
+  jest-runner@30.4.2:
+    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runtime@30.3.0:
-    resolution: {integrity: sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==}
+  jest-runtime@30.4.2:
+    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-snapshot@30.3.0:
-    resolution: {integrity: sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==}
+  jest-snapshot@30.4.1:
+    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-util@30.3.0:
-    resolution: {integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==}
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-validate@30.3.0:
-    resolution: {integrity: sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==}
+  jest-validate@30.4.1:
+    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-watcher@30.3.0:
-    resolution: {integrity: sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==}
+  jest-watcher@30.4.1:
+    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-worker@30.3.0:
-    resolution: {integrity: sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==}
+  jest-worker@30.4.1:
+    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest@30.3.0:
-    resolution: {integrity: sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==}
+  jest@30.4.2:
+    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -3066,11 +3057,6 @@ packages:
   jsdoc@4.0.5:
     resolution: {integrity: sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==}
     engines: {node: '>=12.0.0'}
-    hasBin: true
-
-  jsesc@3.0.2:
-    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
-    engines: {node: '>=6'}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3131,8 +3117,8 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  loctool@2.32.3:
-    resolution: {integrity: sha512-qvX1zm+ALdJcTCboy7gkXsUSaHc2+8G9fvK+1m2kXap0uoeQv7xtiUp2F9JAE7Swll50WrIOtgDi7l0CBCIu8Q==}
+  loctool@2.33.0:
+    resolution: {integrity: sha512-HsHSb+kvjN0kd3bocFWf1zOqaMfiJXd1XzcRq7IfJI06DwMLzqfzj4ceijlZzVpLmcGFvfwqa2ox4h2R0vA5aQ==}
     engines: {node: '>=12 <23'}
     hasBin: true
 
@@ -3297,9 +3283,6 @@ packages:
 
   node-notifier@8.0.2:
     resolution: {integrity: sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==}
-
-  node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3552,8 +3535,8 @@ packages:
   pretty-data@0.40.0:
     resolution: {integrity: sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==}
 
-  pretty-format@30.3.0:
-    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   promise.allsettled@1.0.7:
@@ -3576,6 +3559,9 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+
   read-pkg@3.0.0:
     resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
     engines: {node: '>=4'}
@@ -3596,10 +3582,6 @@ packages:
     resolution: {integrity: sha512-r0Ay04Snci87djAsI4U+WNRcSw5S4pOH7qFjd/veA5gC7TbqESR3tcj28ia95L/fYUDw11JKP7uqUKUAfVvV5Q==}
     engines: {node: '>= 0.4'}
 
-  regenerate-unicode-properties@10.2.0:
-    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
-    engines: {node: '>=4'}
-
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -3614,20 +3596,12 @@ packages:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
 
-  regexpu-core@6.2.0:
-    resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
-    engines: {node: '>=4'}
-
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
     engines: {node: '>=4'}
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
-
-  regjsparser@0.12.0:
-    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
-    hasBin: true
 
   regjsparser@0.13.1:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
@@ -3721,6 +3695,11 @@ packages:
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4046,10 +4025,6 @@ packages:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
     engines: {node: '>=4'}
 
-  unicode-match-property-value-ecmascript@2.2.0:
-    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
-    engines: {node: '>=4'}
-
   unicode-match-property-value-ecmascript@2.2.1:
     resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
     engines: {node: '>=4'}
@@ -4094,12 +4069,6 @@ packages:
 
   unrs-resolver@1.7.13:
     resolution: {integrity: sha512-QUjCYKAgrdJpf3wA73zWjOrO7ra19lfnwQ8HRkNOLah5AVDqOS38UunnyhzsSL8AE+2/AGnAHxlr8cGshCP35A==}
-
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -4251,19 +4220,21 @@ packages:
 
 snapshots:
 
-  '@babel/code-frame@7.27.1':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
+
+  '@babel/compat-data@7.29.7': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -4278,20 +4249,12 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -4301,50 +4264,59 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.27.3':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.4
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      regexpu-core: 6.2.0
-      semver: 6.3.1
-
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
@@ -4353,24 +4325,12 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
+  '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5':
+  '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4381,12 +4341,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4399,61 +4357,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@7.27.1':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
-  '@babel/helper-plugin-utils@7.27.1': {}
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-wrap-function': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.27.1
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helper-wrap-function@7.28.3':
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helper-wrap-function@7.29.7':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.28.5
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4466,46 +4430,54 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
-
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4516,504 +4488,505 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/template': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.5
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.5
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.0)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
@@ -5026,19 +4999,13 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.28.5
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5046,17 +5013,11 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -5066,7 +5027,19 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5075,15 +5048,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -5344,43 +5317,44 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jest/console@30.3.0':
+  '@jest/console@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.3.0(node-notifier@8.0.2)':
+  '@jest/core@30.4.2(node-notifier@8.0.2)':
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0(node-notifier@8.0.2)
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1(node-notifier@8.0.2)
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.2.0
       exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@12.20.55)
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@12.20.55)
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
       slash: 3.0.0
     optionalDependencies:
       node-notifier: 8.0.2
@@ -5390,58 +5364,58 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.3.0': {}
+  '@jest/diff-sequences@30.4.0': {}
 
-  '@jest/environment@30.3.0':
+  '@jest/environment@30.4.1':
     dependencies:
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-mock: 30.3.0
+      jest-mock: 30.4.1
 
-  '@jest/expect-utils@30.3.0':
+  '@jest/expect-utils@30.4.1':
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.3.0':
+  '@jest/expect@30.4.1':
     dependencies:
-      expect: 30.3.0
-      jest-snapshot: 30.3.0
+      expect: 30.4.1
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/fake-timers@30.3.0':
+  '@jest/fake-timers@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
-      '@sinonjs/fake-timers': 15.3.0
+      '@jest/types': 30.4.1
+      '@sinonjs/fake-timers': 15.4.0
       '@types/node': 12.20.55
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.3.0':
+  '@jest/globals@30.4.1':
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/types': 30.3.0
-      jest-mock: 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/pattern@30.0.1':
+  '@jest/pattern@30.4.0':
     dependencies:
       '@types/node': 12.20.55
-      jest-regex-util: 30.0.1
+      jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.3.0(node-notifier@8.0.2)':
+  '@jest/reporters@30.4.1(node-notifier@8.0.2)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.30
       '@types/node': 12.20.55
       chalk: 4.1.2
@@ -5454,9 +5428,9 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       slash: 3.0.0
       string-length: 4.0.2
       v8-to-istanbul: 9.3.0
@@ -5465,13 +5439,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/schemas@30.0.5':
+  '@jest/schemas@30.4.1':
     dependencies:
       '@sinclair/typebox': 0.34.33
 
-  '@jest/snapshot-utils@30.3.0':
+  '@jest/snapshot-utils@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
@@ -5482,43 +5456,43 @@ snapshots:
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
-  '@jest/test-result@30.3.0':
+  '@jest/test-result@30.4.1':
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
 
-  '@jest/test-sequencer@30.3.0':
+  '@jest/test-sequencer@30.4.1':
     dependencies:
-      '@jest/test-result': 30.3.0
+      '@jest/test-result': 30.4.1
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
+      jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.3.0':
+  '@jest/transform@30.4.1':
     dependencies:
       '@babel/core': 7.29.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.30
       babel-plugin-istanbul: 7.0.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
       pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/types@30.3.0':
+  '@jest/types@30.4.1':
     dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 12.20.55
@@ -5596,7 +5570,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.3.0':
+  '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -5607,24 +5581,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/hast@2.3.10':
     dependencies:
@@ -5812,13 +5786,13 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  babel-jest@30.3.0(@babel/core@7.29.0):
+  babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
+      '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.3.0(@babel/core@7.29.0)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -5829,7 +5803,7 @@ snapshots:
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 6.0.3
@@ -5837,13 +5811,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jest-hoist@30.3.0:
+  babel-plugin-jest-hoist@30.4.0:
     dependencies:
       '@types/babel__core': 7.20.5
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -5872,7 +5846,7 @@ snapshots:
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
@@ -5884,10 +5858,10 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-jest@30.3.0(@babel/core@7.29.0):
+  babel-preset-jest@30.4.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      babel-plugin-jest-hoist: 30.3.0
+      babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   bail@1.0.5: {}
@@ -5918,13 +5892,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.25.4:
-    dependencies:
-      caniuse-lite: 1.0.30001739
-      electron-to-chromium: 1.5.211
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.4)
 
   browserslist@4.28.2:
     dependencies:
@@ -5970,8 +5937,6 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001739: {}
 
   caniuse-lite@1.0.30001786: {}
 
@@ -6149,10 +6114,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -6230,8 +6191,6 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
-
-  electron-to-chromium@1.5.211: {}
 
   electron-to-chromium@1.5.332: {}
 
@@ -6378,14 +6337,14 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  expect@30.3.0:
+  expect@30.4.1:
     dependencies:
-      '@jest/expect-utils': 30.3.0
+      '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   extend@3.0.2: {}
 
@@ -6565,7 +6524,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -6794,7 +6753,7 @@ snapshots:
 
   ilib-casemapper@1.0.2:
     dependencies:
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
 
   ilib-common@1.1.7:
@@ -6807,22 +6766,20 @@ snapshots:
     dependencies:
       ilib-common: 1.1.7
 
-  ilib-env@1.4.1: {}
-
   ilib-env@1.4.2: {}
 
   ilib-istring@1.1.1:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
       ilib-localedata: 1.5.2
       regenerator-runtime: 0.14.1
 
   ilib-lint-common@3.7.0: {}
 
-  ilib-lint@2.21.2:
+  ilib-lint@2.21.5:
     dependencies:
       '@formatjs/intl': 2.10.15
       ilib-casemapper: 1.0.2
@@ -6831,9 +6788,9 @@ snapshots:
       ilib-lint-common: 3.7.0
       ilib-locale: 1.4.0
       ilib-localeinfo: 1.1.0
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       ilib-scriptinfo: 1.0.0
-      ilib-tools-common: 1.21.3
+      ilib-tools-common: 1.22.0
       ilib-xliff: 1.4.1
       ilib-xliff-webos: 1.0.11
       intl-messageformat: 10.7.15
@@ -6850,7 +6807,7 @@ snapshots:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       promise.allsettled: 1.0.7
 
   ilib-locale@1.4.0:
@@ -6861,43 +6818,43 @@ snapshots:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-loader: 1.3.5
       ilib-locale: 1.4.0
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       json5: 2.2.3
 
   ilib-localeinfo@1.1.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
       ilib-localedata: 1.5.2
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       json5: 2.2.3
-
-  ilib-localematcher@1.3.1:
-    dependencies:
-      ilib-common: 1.1.7
-      ilib-locale: 1.4.0
 
   ilib-localematcher@1.3.2:
     dependencies:
       ilib-common: 1.1.7
       ilib-locale: 1.4.0
 
-  ilib-po@1.1.4:
+  ilib-localematcher@1.3.4:
+    dependencies:
+      ilib-common: 1.1.7
+      ilib-locale: 1.4.0
+
+  ilib-po@1.1.5:
     dependencies:
       ilib-ctype: 1.3.0
       ilib-locale: 1.4.0
-      ilib-tools-common: 1.21.3
+      ilib-tools-common: 1.22.0
 
   ilib-scriptinfo@1.0.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
 
-  ilib-tools-common@1.21.3:
+  ilib-tools-common@1.22.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
@@ -6927,7 +6884,7 @@ snapshots:
     dependencies:
       sax: 1.4.1
 
-  ilib@14.21.3: {}
+  ilib@14.22.0: {}
 
   import-local@3.2.0:
     dependencies:
@@ -7151,7 +7108,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -7167,7 +7124,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -7190,31 +7147,31 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jest-changed-files@30.3.0:
+  jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.3.0:
+  jest-circus@30.4.2:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
       is-generator-fn: 2.1.0
-      jest-each: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       p-limit: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -7222,17 +7179,17 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@12.20.55)(node-notifier@8.0.2):
+  jest-cli@30.4.2(@types/node@12.20.55)(node-notifier@8.0.2):
     dependencies:
-      '@jest/core': 30.3.0(node-notifier@8.0.2)
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(node-notifier@8.0.2)
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@12.20.55)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-config: 30.4.2(@types/node@12.20.55)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       yargs: 17.7.2
     optionalDependencies:
       node-notifier: 8.0.2
@@ -7243,29 +7200,29 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@12.20.55):
+  jest-config@30.4.2(@types/node@12.20.55):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 4.2.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       parse-json: 5.2.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
@@ -7274,227 +7231,228 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.3.0:
+  jest-diff@30.4.1:
     dependencies:
-      '@jest/diff-sequences': 30.3.0
+      '@jest/diff-sequences': 30.4.0
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-docblock@30.2.0:
+  jest-docblock@30.4.0:
     dependencies:
       detect-newline: 3.1.0
 
-  jest-each@30.3.0:
+  jest-each@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-environment-node@30.3.0:
+  jest-environment-node@30.4.1:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
 
-  jest-haste-map@30.3.0:
+  jest-haste-map@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       picomatch: 4.0.4
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-leak-detector@30.3.0:
+  jest-leak-detector@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-matcher-utils@30.3.0:
+  jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
-      jest-diff: 30.3.0
-      pretty-format: 30.3.0
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-message-util@30.3.0:
+  jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.3.0
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
+      jest-util: 30.4.1
       picomatch: 4.0.4
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock@30.3.0:
+  jest-mock@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-util: 30.3.0
+      jest-util: 30.4.1
 
-  jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
     optionalDependencies:
-      jest-resolve: 30.3.0
+      jest-resolve: 30.4.1
 
-  jest-regex-util@30.0.1: {}
+  jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.3.0:
+  jest-resolve-dependencies@30.4.2:
     dependencies:
-      jest-regex-util: 30.0.1
-      jest-snapshot: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  jest-resolve@30.3.0:
+  jest-resolve@30.4.1:
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-pnp-resolver: 1.2.3(jest-resolve@30.3.0)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       slash: 3.0.0
       unrs-resolver: 1.7.13
 
-  jest-runner@30.3.0:
+  jest-runner@30.4.2:
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/environment': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-haste-map: 30.3.0
-      jest-leak-detector: 30.3.0
-      jest-message-util: 30.3.0
-      jest-resolve: 30.3.0
-      jest-runtime: 30.3.0
-      jest-util: 30.3.0
-      jest-watcher: 30.3.0
-      jest-worker: 30.3.0
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.3.0:
+  jest-runtime@30.4.2:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/globals': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1
       '@jest/source-map': 30.0.1
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.2
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.3.0:
+  jest-snapshot@30.4.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/types': 7.28.5
-      '@jest/expect-utils': 30.3.0
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
-      '@jest/snapshot-utils': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
-      expect: 30.3.0
+      expect: 30.4.1
       graceful-fs: 4.2.11
-      jest-diff: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
       semver: 7.7.2
       synckit: 0.11.8
     transitivePeerDependencies:
       - supports-color
 
-  jest-util@30.3.0:
+  jest-util@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.4
 
-  jest-validate@30.3.0:
+  jest-validate@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       camelcase: 6.3.0
       chalk: 4.1.2
       leven: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-watcher@30.3.0:
+  jest-watcher@30.4.1:
     dependencies:
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       string-length: 4.0.2
 
-  jest-worker@30.3.0:
+  jest-worker@30.4.1:
     dependencies:
       '@types/node': 12.20.55
       '@ungap/structured-clone': 1.3.0
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@12.20.55)(node-notifier@8.0.2):
+  jest@30.4.2(@types/node@12.20.55)(node-notifier@8.0.2):
     dependencies:
-      '@jest/core': 30.3.0(node-notifier@8.0.2)
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(node-notifier@8.0.2)
+      '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+      jest-cli: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -7568,8 +7526,6 @@ snapshots:
       strip-json-comments: 3.1.1
       underscore: 1.13.7
 
-  jsesc@3.0.2: {}
-
   jsesc@3.1.0: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -7631,18 +7587,18 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  loctool@2.32.3:
+  loctool@2.33.0:
     dependencies:
       '@formatjs/intl': 2.10.15
       build-gradle-reader: 1.0.0
       cldr-segmentation: 2.2.1
       he: 1.2.0
       html-parser: 0.11.0
-      ilib: 14.21.3
+      ilib: 14.22.0
       ilib-locale: 1.4.0
       ilib-localematcher: 1.3.2
-      ilib-po: 1.1.4
-      ilib-tools-common: 1.21.3
+      ilib-po: 1.1.5
+      ilib-tools-common: 1.22.0
       ilib-tree-node: 2.0.1
       js-stl: 0.0.6
       js-yaml: 4.1.1
@@ -7826,13 +7782,11 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.7.2
+      semver: 7.8.5
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
     optional: true
-
-  node-releases@2.0.19: {}
 
   node-releases@2.0.37: {}
 
@@ -7988,7 +7942,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -8069,11 +8023,12 @@ snapshots:
 
   pretty-data@0.40.0: {}
 
-  pretty-format@30.3.0:
+  pretty-format@30.4.1:
     dependencies:
-      '@jest/schemas': 30.0.5
+      '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
-      react-is: 18.3.1
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.7
 
   promise.allsettled@1.0.7:
     dependencies:
@@ -8095,6 +8050,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   react-is@18.3.1: {}
+
+  react-is@19.2.7: {}
 
   read-pkg@3.0.0:
     dependencies:
@@ -8126,10 +8083,6 @@ snapshots:
       gopd: 1.2.0
       which-builtin-type: 1.2.1
 
-  regenerate-unicode-properties@10.2.0:
-    dependencies:
-      regenerate: 1.4.2
-
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -8145,15 +8098,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  regexpu-core@6.2.0:
-    dependencies:
-      regenerate: 1.4.2
-      regenerate-unicode-properties: 10.2.0
-      regjsgen: 0.8.0
-      regjsparser: 0.12.0
-      unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.2.0
-
   regexpu-core@6.4.0:
     dependencies:
       regenerate: 1.4.2
@@ -8164,10 +8108,6 @@ snapshots:
       unicode-match-property-value-ecmascript: 2.2.1
 
   regjsgen@0.8.0: {}
-
-  regjsparser@0.12.0:
-    dependencies:
-      jsesc: 3.0.2
 
   regjsparser@0.13.1:
     dependencies:
@@ -8292,6 +8232,9 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  semver@7.8.5:
+    optional: true
 
   set-function-length@1.2.2:
     dependencies:
@@ -8518,7 +8461,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   tmpl@1.0.5: {}
 
@@ -8634,8 +8577,6 @@ snapshots:
       unicode-canonical-property-names-ecmascript: 2.0.1
       unicode-property-aliases-ecmascript: 2.1.0
 
-  unicode-match-property-value-ecmascript@2.2.0: {}
-
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
@@ -8704,12 +8645,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.7.13
       '@unrs/resolver-binding-win32-ia32-msvc': 1.7.13
       '@unrs/resolver-binding-win32-x64-msvc': 1.7.13
-
-  update-browserslist-db@1.1.3(browserslist@4.25.4):
-    dependencies:
-      browserslist: 4.25.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
* Update dependencies (loctool: 2.33.0,  ilib: 14.22.0, ...)
  * Update dependency versions across packages by update-dependencies.sh.
Keep @babel/core and @babel/preset-env on ^7.x in ilib-xliff-webos
because grunt-babel@8 still requires @babel/core via CommonJS require(),
which fails on the ESM-only Babel 8 (ERR_REQUIRE_ESM). 
* Update sample project configs to use `projectType: "custom"`
* webos-json-resource: Derive webOS project type from plugins instead of `projectType`

### Links
