### PR TITLE
Update dependencies (loctool: 2.33.1)

### DIFF
--- a/.changeset/lucky-mails-tickle.md
+++ b/.changeset/lucky-mails-tickle.md
@@ -1,0 +1,16 @@
+---
+"ilib-loctool-webos-json-resource": patch
+"ilib-loctool-webos-ts-resource": patch
+"ilib-loctool-webos-javascript": patch
+"ilib-loctool-webos-common": patch
+"ilib-loctool-webos-dart": patch
+"ilib-loctool-webos-dist": patch
+"ilib-loctool-webos-json": patch
+"ilib-loctool-webos-cpp": patch
+"ilib-loctool-webos-qml": patch
+"ilib-loctool-webos-c": patch
+"ilib-xliff-webos": patch
+"ilib-lint-webos": patch
+---
+
+Update dependencies (loctool: 2.33.1)

--- a/packages/ilib-lint-webos/package.json
+++ b/packages/ilib-lint-webos/package.json
@@ -66,7 +66,7 @@
     },
     "devDependencies": {
         "docdash": "^2.0.2",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "jsdoc": "^4.0.5",
         "jsdoc-to-markdown": "^9.1.3",
         "npm-run-all": "^4.1.5",

--- a/packages/ilib-loctool-webos-c/package.json
+++ b/packages/ilib-loctool-webos-c/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-c/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-c": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-common/package.json
+++ b/packages/ilib-loctool-webos-common/package.json
@@ -36,10 +36,10 @@
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource/package.json
+++ b/packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource/package.json
@@ -25,6 +25,6 @@
         "MockResourceFile.js"
     ],
     "dependencies": {
-        "ilib": "^14.21.3"
+        "ilib": "^14.22.0"
     }
 }

--- a/packages/ilib-loctool-webos-cpp/package.json
+++ b/packages/ilib-loctool-webos-cpp/package.json
@@ -57,10 +57,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-cpp": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-dart/package.json
+++ b/packages/ilib-loctool-webos-dart/package.json
@@ -54,14 +54,14 @@
     "dependencies": {
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     "dependencies": {
         "ilib-loctool-webos-dart": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-dist/package.json
+++ b/packages/ilib-loctool-webos-dist/package.json
@@ -37,6 +37,6 @@
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/package.json
+++ b/packages/ilib-loctool-webos-javascript/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/package.json
@@ -14,10 +14,10 @@
     "dependencies": {
         "ilib-loctool-webos-javascript": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "ilib": "^14.21.3",
-        "jest": "^30.3.0"
+        "ilib": "^14.22.0",
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-json-resource/package.json
+++ b/packages/ilib-loctool-webos-json-resource/package.json
@@ -54,13 +54,13 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3"
+        "ilib": "^14.22.0"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-json/package.json
+++ b/packages/ilib-loctool-webos-json/package.json
@@ -51,15 +51,15 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "micromatch": "^4.0.8"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3",
+        "jest": "^30.4.2",
+        "loctool": "2.33.1",
         "ilib-loctool-webos-common": "workspace:*"
     }
 }

--- a/packages/ilib-loctool-webos-json/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-json/test/integrationTest/package.json
@@ -13,9 +13,9 @@
     },
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-qml/package.json
+++ b/packages/ilib-loctool-webos-qml/package.json
@@ -56,10 +56,10 @@
         "ilib-loctool-webos-common": "workspace:*"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-loctool-webos-qml/test/integrationTest/package.json
+++ b/packages/ilib-loctool-webos-qml/test/integrationTest/package.json
@@ -13,10 +13,10 @@
     "dependencies": {
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.1",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/ilib-loctool-webos-ts-resource/package.json
+++ b/packages/ilib-loctool-webos-ts-resource/package.json
@@ -53,15 +53,15 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.21.3",
+        "ilib": "^14.22.0",
         "pretty-data": "^0.40.0",
         "xml-js": "^1.6.11"
     },
     "peerDependencies": {
-        "loctool": "2.32.3"
+        "loctool": "2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0",
-        "loctool": "2.32.3"
+        "jest": "^30.4.2",
+        "loctool": "2.33.1"
     }
 }

--- a/packages/ilib-xliff-webos/package.json
+++ b/packages/ilib-xliff-webos/package.json
@@ -61,7 +61,7 @@
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-babel": "^8.0.0",
         "grunt": "^1.6.2",
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     },
     "dependencies": {
         "ilib-common": "^1.1.7",

--- a/packages/samples-lint/package.json
+++ b/packages/samples-lint/package.json
@@ -49,10 +49,10 @@
         "test-snapshot-update": "pnpm test:jest -u"
     },
     "dependencies": {
-        "ilib-lint": "^2.21.2",
+        "ilib-lint": "^2.21.5",
         "ilib-lint-webos": "workspace:*",
         "xml-js": "^1.6.11",
-        "jest": "^30.3.0",
+        "jest": "^30.4.2",
         "cheerio": "^1.2.0"
     }
 }

--- a/packages/samples-loctool/webos-c/package.json
+++ b/packages/samples-loctool/webos-c/package.json
@@ -20,9 +20,9 @@
         "ilib-loctool-webos-c": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-cpp/package.json
+++ b/packages/samples-loctool/webos-cpp/package.json
@@ -20,9 +20,9 @@
         "ilib-loctool-webos-cpp": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-dart/package.json
+++ b/packages/samples-loctool/webos-dart/package.json
@@ -21,9 +21,9 @@
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-js/package.json
+++ b/packages/samples-loctool/webos-js/package.json
@@ -21,10 +21,10 @@
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-json-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "ilib": "^14.21.3",
-        "jest": "^30.3.0"
+        "ilib": "^14.22.0",
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-json/package.json
+++ b/packages/samples-loctool/webos-json/package.json
@@ -18,9 +18,9 @@
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3"
+        "loctool": "^2.33.1"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-json/subDirCase/package.json
+++ b/packages/samples-loctool/webos-json/subDirCase/package.json
@@ -13,10 +13,10 @@
     "dependencies": {
         "ilib-loctool-webos-json": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.1",
         "micromatch": "^4.0.8"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/packages/samples-loctool/webos-qml/package.json
+++ b/packages/samples-loctool/webos-qml/package.json
@@ -19,10 +19,10 @@
         "ilib-loctool-webos-qml": "workspace:*",
         "ilib-loctool-webos-ts-resource": "workspace:*",
         "ilib-loctool-webos-common": "workspace:*",
-        "loctool": "^2.32.3",
+        "loctool": "^2.33.1",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "jest": "^30.3.0"
+        "jest": "^30.4.2"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       jsdoc:
         specifier: ^4.0.5
         version: 4.0.5
@@ -56,11 +56,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-c/test/integrationTest:
     dependencies:
@@ -71,29 +71,29 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-common:
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-common/test/ilib-loctool-mock: {}
 
   packages/ilib-loctool-webos-common/test/ilib-loctool-mock-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
 
   packages/ilib-loctool-webos-cpp:
     dependencies:
@@ -105,11 +105,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-cpp/test/integrationTest:
     dependencies:
@@ -120,18 +120,18 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-dart:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       ilib-loctool-webos-common:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-common
@@ -143,11 +143,11 @@ importers:
         version: 4.0.8
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-dart/test/integrationTest:
     dependencies:
@@ -158,12 +158,12 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-dist:
     dependencies:
@@ -192,8 +192,8 @@ importers:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-javascript:
     dependencies:
@@ -205,11 +205,11 @@ importers:
         version: link:../ilib-loctool-webos-json-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-javascript/test/integrationTest:
     dependencies:
@@ -220,21 +220,21 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-json:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -243,24 +243,24 @@ importers:
         specifier: workspace:*
         version: link:../ilib-loctool-webos-common
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-json-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-json/test/integrationTest:
     dependencies:
@@ -268,12 +268,12 @@ importers:
         specifier: workspace:*
         version: link:../..
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-qml:
     dependencies:
@@ -285,11 +285,11 @@ importers:
         version: link:../ilib-loctool-webos-ts-resource
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-loctool-webos-qml/test/integrationTest:
     dependencies:
@@ -300,21 +300,21 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/ilib-loctool-webos-ts-resource:
     dependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       pretty-data:
         specifier: ^0.40.0
         version: 0.40.0
@@ -323,11 +323,11 @@ importers:
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       loctool:
-        specifier: 2.32.3
-        version: 2.32.3
+        specifier: 2.33.1
+        version: 2.33.1
 
   packages/ilib-xliff-webos:
     dependencies:
@@ -357,8 +357,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       load-grunt-tasks:
         specifier: ^5.1.0
         version: 5.1.0(grunt@1.6.2)
@@ -375,14 +375,14 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       ilib-lint:
-        specifier: ^2.21.2
-        version: 2.21.2
+        specifier: ^2.21.5
+        version: 2.21.5
       ilib-lint-webos:
         specifier: workspace:*
         version: link:../ilib-lint-webos
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -401,12 +401,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-cpp:
     dependencies:
@@ -420,12 +420,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-dart:
     dependencies:
@@ -442,12 +442,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-js:
     dependencies:
@@ -464,15 +464,15 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       ilib:
-        specifier: ^14.21.3
-        version: 14.21.3
+        specifier: ^14.22.0
+        version: 14.22.0
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-json:
     dependencies:
@@ -483,12 +483,12 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-json/subDirCase:
     dependencies:
@@ -499,15 +499,15 @@ importers:
         specifier: workspace:*
         version: link:../../../ilib-loctool-webos-json
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
   packages/samples-loctool/webos-qml:
     dependencies:
@@ -524,15 +524,15 @@ importers:
         specifier: workspace:*
         version: link:../../ilib-loctool-webos-ts-resource
       loctool:
-        specifier: ^2.32.3
-        version: 2.32.3
+        specifier: ^2.33.1
+        version: 2.33.1
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
     devDependencies:
       jest:
-        specifier: ^30.3.0
-        version: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
 packages:
 
@@ -625,10 +625,6 @@ packages:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.27.1':
-    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.28.6':
@@ -755,12 +751,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.28.6':
     resolution: {integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1322,12 +1312,12 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jest/console@30.3.0':
-    resolution: {integrity: sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==}
+  '@jest/console@30.4.1':
+    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/core@30.3.0':
-    resolution: {integrity: sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==}
+  '@jest/core@30.4.2':
+    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1335,40 +1325,40 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/diff-sequences@30.3.0':
-    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/environment@30.3.0':
-    resolution: {integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==}
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect-utils@30.3.0':
-    resolution: {integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==}
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect@30.3.0':
-    resolution: {integrity: sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==}
+  '@jest/expect@30.4.1':
+    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/fake-timers@30.3.0':
-    resolution: {integrity: sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==}
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/get-type@30.1.0':
     resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/globals@30.3.0':
-    resolution: {integrity: sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==}
+  '@jest/globals@30.4.1':
+    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/pattern@30.0.1':
-    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/reporters@30.3.0':
-    resolution: {integrity: sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==}
+  '@jest/reporters@30.4.1':
+    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -1376,32 +1366,32 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/snapshot-utils@30.3.0':
-    resolution: {integrity: sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==}
+  '@jest/snapshot-utils@30.4.1':
+    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/source-map@30.0.1':
     resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-result@30.3.0':
-    resolution: {integrity: sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==}
+  '@jest/test-result@30.4.1':
+    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-sequencer@30.3.0':
-    resolution: {integrity: sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==}
+  '@jest/test-sequencer@30.4.1':
+    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/transform@30.3.0':
-    resolution: {integrity: sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==}
+  '@jest/transform@30.4.1':
+    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/types@30.3.0':
-    resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1462,8 +1452,8 @@ packages:
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
-  '@sinonjs/fake-timers@15.3.0':
-    resolution: {integrity: sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==}
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -1527,6 +1517,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.7.13':
     resolution: {integrity: sha512-LIKeCzNSkTWwGHjtiUIfvS96+7kpuyrKq2pzw/0XT2S8ykczj40Hh27oLTbXguCX8tGrCoaD2yXxzwqMMhAzhA==}
@@ -1705,8 +1696,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  babel-jest@30.3.0:
-    resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
+  babel-jest@30.4.1:
+    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-0
@@ -1718,8 +1709,8 @@ packages:
     resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
     engines: {node: '>=12'}
 
-  babel-plugin-jest-hoist@30.3.0:
-    resolution: {integrity: sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==}
+  babel-plugin-jest-hoist@30.4.0:
+    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-plugin-polyfill-corejs2@0.4.17:
@@ -1742,8 +1733,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
 
-  babel-preset-jest@30.3.0:
-    resolution: {integrity: sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==}
+  babel-preset-jest@30.4.0:
+    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
@@ -2216,8 +2207,8 @@ packages:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
 
-  expect@30.3.0:
-    resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   extend@3.0.2:
@@ -2565,9 +2556,6 @@ packages:
   ilib-ctype@1.3.0:
     resolution: {integrity: sha512-NiEnz7/aSwCws1PDuYQi4m4AITrhGOeFqd6Tfvnc85wLyRZUVuOlVs5RFCA5rDSN0wdlzW25BT/NBG5kzV+Ggw==}
 
-  ilib-env@1.4.1:
-    resolution: {integrity: sha512-lhXj5AaOT6AAft3eSFTqncNSYhqMdXAq9RpAeCral1tJpZDmzxhxpnKcFghgbjk9NkFFBRxFxTIAkgSq9NfEfQ==}
-
   ilib-env@1.4.2:
     resolution: {integrity: sha512-H/nFk+qnC6hfgD6bgaSF+mohZUWqtfjQmStBCU3c832vv00Vtco6GrOSGaXwdr3QgnhzxL8zhLOUTtSTJ2gHxA==}
 
@@ -2578,8 +2566,8 @@ packages:
     resolution: {integrity: sha512-N9kB+DRhByIJROv0QcFz3NogNSjs61wu7hXrysz7H2gpAnYvZU/2RGxlCMC4vDm5tiQnHM5N1QKpmKhy/tVJhQ==}
     engines: {node: '>=12 <23'}
 
-  ilib-lint@2.21.2:
-    resolution: {integrity: sha512-Hjw3b/O5wx9SFlsXuM8sG00BsQLYy+9d/2nlbgUIHzWZ/oTqzqW2Bdto5FY5swhAt6ewtoC6Wj9gHgiOKoiEhQ==}
+  ilib-lint@2.21.5:
+    resolution: {integrity: sha512-pNQp5PrIGsAspdcdbv3hdtUjIL+w7lfWik6hnpvze/INAqHjchQJjQNTaT9LttphYEOBEGP3NJIlWV4D7Bup2g==}
     engines: {node: '>=12 <23'}
     hasBin: true
 
@@ -2596,22 +2584,23 @@ packages:
   ilib-localeinfo@1.1.0:
     resolution: {integrity: sha512-F77DV01lWANKqEw1QxEqYNO3Jj3H30kkYMGinMWoCIF18Kb/Gc/aJaaENWlS9kfZkbvfXthcBL7kuswMY+Hjdg==}
 
-  ilib-localematcher@1.3.1:
-    resolution: {integrity: sha512-sDqSdYfAouyGH9OPKPuXk2Lyb4+HU3Gz05bLTJ5fn3FRn/IzG5sUQjSrhfmQAsklQ6WLlJE3nL5wbpV0fpX8Lw==}
-
   ilib-localematcher@1.3.2:
     resolution: {integrity: sha512-v+2rT11WOMlDQesseIYm4Kb9L6072SqLU7oObY3wPDh51Cr3s25bI8YEX+5VUT/YEN1e7h3bUslWt6huzlv62g==}
     engines: {node: '>=12 <23'}
 
-  ilib-po@1.1.4:
-    resolution: {integrity: sha512-YHea8MT1dF3lhb5vIYtL0eobjXWaEO29+wesWbYozsjMQZemf+gl6ehg0fNkWTnRKMC/b0kGpwM6KaTkuyOKrw==}
+  ilib-localematcher@1.3.4:
+    resolution: {integrity: sha512-UildyR0Dj8HeqN6/I7NwPoOoY0yX9NSlWlTA/PLrC4qozmcHbWkal7KPvcUjriSQfvpivHj/R0qx2TxbRXWkFg==}
+    engines: {node: '>=14 <23'}
+
+  ilib-po@1.1.5:
+    resolution: {integrity: sha512-MLm6Dh2+h/IVAIHuKgW54HoktOfAZOvTx6DldNxUkSRN6LbRFg83pw2S1wDLCykRWX6fvzBoIA0wqHYy81jl+w==}
     engines: {node: '>=12 <23'}
 
   ilib-scriptinfo@1.0.0:
     resolution: {integrity: sha512-GlMitfrpa5/27wxr3leG7Bri6GVD1yWBNAGyAOi0TWxjq/Zuo9n8CLYem4XIkqlCpUXbo5phPGZXCR2fWo39ig==}
 
-  ilib-tools-common@1.21.3:
-    resolution: {integrity: sha512-9GwF/DhD0W1HnccH/lWiEMkFz54mRSbfwrAKuLq3WcMn+XmJIU3qEUfq/6zgR7Nf8MjcMKGlFXkEvsFDTd21CA==}
+  ilib-tools-common@1.22.0:
+    resolution: {integrity: sha512-vTa3Z4WTt+clr/f/o2sZNjaYQuEosDiKNza+8zP0QbUojsugm4RprdsqNn8bgk2d1j/LIgqq1slwR+MZ5XIxcg==}
     engines: {node: '>=12 <23'}
 
   ilib-tree-node@2.0.1:
@@ -2627,8 +2616,8 @@ packages:
     resolution: {integrity: sha512-u2Uitc6238fQzIpwHx7qTt0GDii6ncBKtbLX6lvg67+x2iyQ4tz3nycyXg+c8wdaaVgqVGeBNs48uYGEKVJzkA==}
     hasBin: true
 
-  ilib@14.21.3:
-    resolution: {integrity: sha512-HQA76PAVwsjRxVUI7SzYaes4lOSEFkbED/klnWm/y3uOrLIJh1vZgMIlRp71AGq/rOQDdbtiF51hkxcnEHePlQ==}
+  ilib@14.22.0:
+    resolution: {integrity: sha512-N3Rj+B1BwVPjhl5z67lKfTepGYos9Yfx5dosRDnh5pmVKv69eHYXyN5MG2yv3FRS9ilygSE8DEC7fm6Yleng6A==}
     engines: {node: '>=8 <25'}
 
   import-local@3.2.0:
@@ -2895,16 +2884,16 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jest-changed-files@30.3.0:
-    resolution: {integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==}
+  jest-changed-files@30.4.1:
+    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-circus@30.3.0:
-    resolution: {integrity: sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==}
+  jest-circus@30.4.2:
+    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-cli@30.3.0:
-    resolution: {integrity: sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==}
+  jest-cli@30.4.2:
+    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -2913,8 +2902,8 @@ packages:
       node-notifier:
         optional: true
 
-  jest-config@30.3.0:
-    resolution: {integrity: sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==}
+  jest-config@30.4.2:
+    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -2928,40 +2917,40 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.3.0:
-    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-docblock@30.2.0:
-    resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
+  jest-docblock@30.4.0:
+    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-each@30.3.0:
-    resolution: {integrity: sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==}
+  jest-each@30.4.1:
+    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-environment-node@30.3.0:
-    resolution: {integrity: sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==}
+  jest-environment-node@30.4.1:
+    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-haste-map@30.3.0:
-    resolution: {integrity: sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==}
+  jest-haste-map@30.4.1:
+    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-leak-detector@30.3.0:
-    resolution: {integrity: sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==}
+  jest-leak-detector@30.4.1:
+    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.3.0:
-    resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.3.0:
-    resolution: {integrity: sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==}
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-mock@30.3.0:
-    resolution: {integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==}
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
@@ -2973,48 +2962,48 @@ packages:
       jest-resolve:
         optional: true
 
-  jest-regex-util@30.0.1:
-    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve-dependencies@30.3.0:
-    resolution: {integrity: sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==}
+  jest-resolve-dependencies@30.4.2:
+    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve@30.3.0:
-    resolution: {integrity: sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==}
+  jest-resolve@30.4.1:
+    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runner@30.3.0:
-    resolution: {integrity: sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==}
+  jest-runner@30.4.2:
+    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runtime@30.3.0:
-    resolution: {integrity: sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==}
+  jest-runtime@30.4.2:
+    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-snapshot@30.3.0:
-    resolution: {integrity: sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==}
+  jest-snapshot@30.4.1:
+    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-util@30.3.0:
-    resolution: {integrity: sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==}
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-validate@30.3.0:
-    resolution: {integrity: sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==}
+  jest-validate@30.4.1:
+    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-watcher@30.3.0:
-    resolution: {integrity: sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==}
+  jest-watcher@30.4.1:
+    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-worker@30.3.0:
-    resolution: {integrity: sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==}
+  jest-worker@30.4.1:
+    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest@30.3.0:
-    resolution: {integrity: sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==}
+  jest@30.4.2:
+    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -3131,8 +3120,8 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  loctool@2.32.3:
-    resolution: {integrity: sha512-qvX1zm+ALdJcTCboy7gkXsUSaHc2+8G9fvK+1m2kXap0uoeQv7xtiUp2F9JAE7Swll50WrIOtgDi7l0CBCIu8Q==}
+  loctool@2.33.1:
+    resolution: {integrity: sha512-PhS8bl71NSz0Q3vQ4BpFXafhXmWHH97NZghfmJcILvc9DtPtzwIG+XL45iIj1g3kogz0Mb8zNd2cotk0h4SzuQ==}
     engines: {node: '>=12 <23'}
     hasBin: true
 
@@ -3552,8 +3541,8 @@ packages:
   pretty-data@0.40.0:
     resolution: {integrity: sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==}
 
-  pretty-format@30.3.0:
-    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   promise.allsettled@1.0.7:
@@ -3575,6 +3564,9 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   read-pkg@3.0.0:
     resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
@@ -4403,8 +4395,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/helper-plugin-utils@7.27.1': {}
-
   '@babel/helper-plugin-utils@7.28.6': {}
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
@@ -4516,32 +4506,27 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -4551,62 +4536,62 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
     dependencies:
@@ -5344,43 +5329,44 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jest/console@30.3.0':
+  '@jest/console@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.3.0(node-notifier@8.0.2)':
+  '@jest/core@30.4.2(node-notifier@8.0.2)':
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0(node-notifier@8.0.2)
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1(node-notifier@8.0.2)
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.2.0
       exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@12.20.55)
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@12.20.55)
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
       slash: 3.0.0
     optionalDependencies:
       node-notifier: 8.0.2
@@ -5390,58 +5376,58 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.3.0': {}
+  '@jest/diff-sequences@30.4.0': {}
 
-  '@jest/environment@30.3.0':
+  '@jest/environment@30.4.1':
     dependencies:
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-mock: 30.3.0
+      jest-mock: 30.4.1
 
-  '@jest/expect-utils@30.3.0':
+  '@jest/expect-utils@30.4.1':
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.3.0':
+  '@jest/expect@30.4.1':
     dependencies:
-      expect: 30.3.0
-      jest-snapshot: 30.3.0
+      expect: 30.4.1
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/fake-timers@30.3.0':
+  '@jest/fake-timers@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
-      '@sinonjs/fake-timers': 15.3.0
+      '@jest/types': 30.4.1
+      '@sinonjs/fake-timers': 15.4.0
       '@types/node': 12.20.55
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.3.0':
+  '@jest/globals@30.4.1':
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/types': 30.3.0
-      jest-mock: 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/pattern@30.0.1':
+  '@jest/pattern@30.4.0':
     dependencies:
       '@types/node': 12.20.55
-      jest-regex-util: 30.0.1
+      jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.3.0(node-notifier@8.0.2)':
+  '@jest/reporters@30.4.1(node-notifier@8.0.2)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.30
       '@types/node': 12.20.55
       chalk: 4.1.2
@@ -5454,9 +5440,9 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       slash: 3.0.0
       string-length: 4.0.2
       v8-to-istanbul: 9.3.0
@@ -5465,13 +5451,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/schemas@30.0.5':
+  '@jest/schemas@30.4.1':
     dependencies:
       '@sinclair/typebox': 0.34.33
 
-  '@jest/snapshot-utils@30.3.0':
+  '@jest/snapshot-utils@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
@@ -5482,43 +5468,43 @@ snapshots:
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
-  '@jest/test-result@30.3.0':
+  '@jest/test-result@30.4.1':
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
 
-  '@jest/test-sequencer@30.3.0':
+  '@jest/test-sequencer@30.4.1':
     dependencies:
-      '@jest/test-result': 30.3.0
+      '@jest/test-result': 30.4.1
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
+      jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.3.0':
+  '@jest/transform@30.4.1':
     dependencies:
       '@babel/core': 7.29.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.30
       babel-plugin-istanbul: 7.0.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
       pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/types@30.3.0':
+  '@jest/types@30.4.1':
     dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 12.20.55
@@ -5596,7 +5582,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.3.0':
+  '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -5607,24 +5593,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/hast@2.3.10':
     dependencies:
@@ -5812,13 +5798,13 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  babel-jest@30.3.0(@babel/core@7.29.0):
+  babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
+      '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.3.0(@babel/core@7.29.0)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -5829,7 +5815,7 @@ snapshots:
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 6.0.3
@@ -5837,7 +5823,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jest-hoist@30.3.0:
+  babel-plugin-jest-hoist@30.4.0:
     dependencies:
       '@types/babel__core': 7.20.5
 
@@ -5872,7 +5858,7 @@ snapshots:
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
@@ -5884,10 +5870,10 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-jest@30.3.0(@babel/core@7.29.0):
+  babel-preset-jest@30.4.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
-      babel-plugin-jest-hoist: 30.3.0
+      babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   bail@1.0.5: {}
@@ -6378,14 +6364,14 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  expect@30.3.0:
+  expect@30.4.1:
     dependencies:
-      '@jest/expect-utils': 30.3.0
+      '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   extend@3.0.2: {}
 
@@ -6565,7 +6551,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -6794,7 +6780,7 @@ snapshots:
 
   ilib-casemapper@1.0.2:
     dependencies:
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
 
   ilib-common@1.1.7:
@@ -6807,22 +6793,20 @@ snapshots:
     dependencies:
       ilib-common: 1.1.7
 
-  ilib-env@1.4.1: {}
-
   ilib-env@1.4.2: {}
 
   ilib-istring@1.1.1:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
       ilib-localedata: 1.5.2
       regenerator-runtime: 0.14.1
 
   ilib-lint-common@3.7.0: {}
 
-  ilib-lint@2.21.2:
+  ilib-lint@2.21.5:
     dependencies:
       '@formatjs/intl': 2.10.15
       ilib-casemapper: 1.0.2
@@ -6831,9 +6815,9 @@ snapshots:
       ilib-lint-common: 3.7.0
       ilib-locale: 1.4.0
       ilib-localeinfo: 1.1.0
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       ilib-scriptinfo: 1.0.0
-      ilib-tools-common: 1.21.3
+      ilib-tools-common: 1.22.0
       ilib-xliff: 1.4.1
       ilib-xliff-webos: 1.0.11
       intl-messageformat: 10.7.15
@@ -6850,7 +6834,7 @@ snapshots:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       promise.allsettled: 1.0.7
 
   ilib-locale@1.4.0:
@@ -6861,43 +6845,43 @@ snapshots:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-loader: 1.3.5
       ilib-locale: 1.4.0
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       json5: 2.2.3
 
   ilib-localeinfo@1.1.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
-      ilib-env: 1.4.1
+      ilib-env: 1.4.2
       ilib-locale: 1.4.0
       ilib-localedata: 1.5.2
-      ilib-localematcher: 1.3.1
+      ilib-localematcher: 1.3.4
       json5: 2.2.3
-
-  ilib-localematcher@1.3.1:
-    dependencies:
-      ilib-common: 1.1.7
-      ilib-locale: 1.4.0
 
   ilib-localematcher@1.3.2:
     dependencies:
       ilib-common: 1.1.7
       ilib-locale: 1.4.0
 
-  ilib-po@1.1.4:
+  ilib-localematcher@1.3.4:
+    dependencies:
+      ilib-common: 1.1.7
+      ilib-locale: 1.4.0
+
+  ilib-po@1.1.5:
     dependencies:
       ilib-ctype: 1.3.0
       ilib-locale: 1.4.0
-      ilib-tools-common: 1.21.3
+      ilib-tools-common: 1.22.0
 
   ilib-scriptinfo@1.0.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
 
-  ilib-tools-common@1.21.3:
+  ilib-tools-common@1.22.0:
     dependencies:
       '@log4js-node/log4js-api': 1.0.2
       ilib-common: 1.1.7
@@ -6927,7 +6911,7 @@ snapshots:
     dependencies:
       sax: 1.4.1
 
-  ilib@14.21.3: {}
+  ilib@14.22.0: {}
 
   import-local@3.2.0:
     dependencies:
@@ -7151,7 +7135,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -7167,7 +7151,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -7190,31 +7174,31 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jest-changed-files@30.3.0:
+  jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.3.0:
+  jest-circus@30.4.2:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.6.0
       is-generator-fn: 2.1.0
-      jest-each: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       p-limit: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -7222,17 +7206,17 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@12.20.55)(node-notifier@8.0.2):
+  jest-cli@30.4.2(@types/node@12.20.55)(node-notifier@8.0.2):
     dependencies:
-      '@jest/core': 30.3.0(node-notifier@8.0.2)
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(node-notifier@8.0.2)
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@12.20.55)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-config: 30.4.2(@types/node@12.20.55)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       yargs: 17.7.2
     optionalDependencies:
       node-notifier: 8.0.2
@@ -7243,29 +7227,29 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@12.20.55):
+  jest-config@30.4.2(@types/node@12.20.55):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 4.2.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       parse-json: 5.2.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
@@ -7274,227 +7258,228 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.3.0:
+  jest-diff@30.4.1:
     dependencies:
-      '@jest/diff-sequences': 30.3.0
+      '@jest/diff-sequences': 30.4.0
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-docblock@30.2.0:
+  jest-docblock@30.4.0:
     dependencies:
       detect-newline: 3.1.0
 
-  jest-each@30.3.0:
+  jest-each@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-environment-node@30.3.0:
+  jest-environment-node@30.4.1:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
 
-  jest-haste-map@30.3.0:
+  jest-haste-map@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       picomatch: 4.0.4
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-leak-detector@30.3.0:
+  jest-leak-detector@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-matcher-utils@30.3.0:
+  jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
-      jest-diff: 30.3.0
-      pretty-format: 30.3.0
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-message-util@30.3.0:
+  jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.3.0
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
+      jest-util: 30.4.1
       picomatch: 4.0.4
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock@30.3.0:
+  jest-mock@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
-      jest-util: 30.3.0
+      jest-util: 30.4.1
 
-  jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
     optionalDependencies:
-      jest-resolve: 30.3.0
+      jest-resolve: 30.4.1
 
-  jest-regex-util@30.0.1: {}
+  jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.3.0:
+  jest-resolve-dependencies@30.4.2:
     dependencies:
-      jest-regex-util: 30.0.1
-      jest-snapshot: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  jest-resolve@30.3.0:
+  jest-resolve@30.4.1:
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-pnp-resolver: 1.2.3(jest-resolve@30.3.0)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       slash: 3.0.0
       unrs-resolver: 1.7.13
 
-  jest-runner@30.3.0:
+  jest-runner@30.4.2:
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/environment': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-haste-map: 30.3.0
-      jest-leak-detector: 30.3.0
-      jest-message-util: 30.3.0
-      jest-resolve: 30.3.0
-      jest-runtime: 30.3.0
-      jest-util: 30.3.0
-      jest-watcher: 30.3.0
-      jest-worker: 30.3.0
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.3.0:
+  jest-runtime@30.4.2:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/globals': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1
       '@jest/source-map': 30.0.1
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.2
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.3.0:
+  jest-snapshot@30.4.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/types': 7.28.5
-      '@jest/expect-utils': 30.3.0
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
-      '@jest/snapshot-utils': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
-      expect: 30.3.0
+      expect: 30.4.1
       graceful-fs: 4.2.11
-      jest-diff: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
       semver: 7.7.2
       synckit: 0.11.8
     transitivePeerDependencies:
       - supports-color
 
-  jest-util@30.3.0:
+  jest-util@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.4
 
-  jest-validate@30.3.0:
+  jest-validate@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       camelcase: 6.3.0
       chalk: 4.1.2
       leven: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-watcher@30.3.0:
+  jest-watcher@30.4.1:
     dependencies:
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 12.20.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       string-length: 4.0.2
 
-  jest-worker@30.3.0:
+  jest-worker@30.4.1:
     dependencies:
       '@types/node': 12.20.55
       '@ungap/structured-clone': 1.3.0
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@12.20.55)(node-notifier@8.0.2):
+  jest@30.4.2(@types/node@12.20.55)(node-notifier@8.0.2):
     dependencies:
-      '@jest/core': 30.3.0(node-notifier@8.0.2)
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(node-notifier@8.0.2)
+      '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@12.20.55)(node-notifier@8.0.2)
+      jest-cli: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -7631,18 +7616,18 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  loctool@2.32.3:
+  loctool@2.33.1:
     dependencies:
       '@formatjs/intl': 2.10.15
       build-gradle-reader: 1.0.0
       cldr-segmentation: 2.2.1
       he: 1.2.0
       html-parser: 0.11.0
-      ilib: 14.21.3
+      ilib: 14.22.0
       ilib-locale: 1.4.0
       ilib-localematcher: 1.3.2
-      ilib-po: 1.1.4
-      ilib-tools-common: 1.21.3
+      ilib-po: 1.1.5
+      ilib-tools-common: 1.22.0
       ilib-tree-node: 2.0.1
       js-stl: 0.0.6
       js-yaml: 4.1.1
@@ -7988,7 +7973,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -8069,11 +8054,12 @@ snapshots:
 
   pretty-data@0.40.0: {}
 
-  pretty-format@30.3.0:
+  pretty-format@30.4.1:
     dependencies:
-      '@jest/schemas': 30.0.5
+      '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
-      react-is: 18.3.1
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.7
 
   promise.allsettled@1.0.7:
     dependencies:
@@ -8095,6 +8081,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   react-is@18.3.1: {}
+
+  react-is@19.2.7: {}
 
   read-pkg@3.0.0:
     dependencies:
@@ -8518,7 +8506,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
* Update dependencies (loctool: 2.33.0,  ilib: 14.22.0, ...)
  * Update dependency versions across packages by update-dependencies.sh.
Keep @babel/core and @babel/preset-env on ^7.x in ilib-xliff-webos
because grunt-babel@8 still requires @babel/core via CommonJS require(),
which fails on the ESM-only Babel 8 (ERR_REQUIRE_ESM). 

### Links
