### PR TITLE
webos-dart: Update key extraction to avoid compressing source text

### DIFF
--- a/.changeset/cozy-parks-wear.md
+++ b/.changeset/cozy-parks-wear.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-dart:
+- Fix a Dart key extraction bug: do not compress source text when generating resource keys, matching C/C++ behavior.

--- a/.changeset/tough-worlds-allow.md
+++ b/.changeset/tough-worlds-allow.md
@@ -2,4 +2,4 @@
 "ilib-loctool-webos-dart": patch
 ---
 
-Use uncompressed source text as resource key
+Fix a Dart key extraction bug: do not compress source text when generating resource keys, matching C/C++ behavior.

--- a/.changeset/tough-worlds-allow.md
+++ b/.changeset/tough-worlds-allow.md
@@ -1,0 +1,5 @@
+---
+"ilib-loctool-webos-dart": patch
+---
+
+Use uncompressed source text as resource key

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -1,7 +1,7 @@
 /*
  * CApp.test.js - test the localization result of webos-c app.
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         }
      });
     test("csample_test_ko_KR", function() {
-        expect.assertions(5);
+        expect.assertions(6);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -104,6 +104,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         expect(jsonData["OK"]).toBe("확인");
         expect(jsonData["Yes"]).toBe("예");
         expect(jsonData["NOT AVAILABLE"]).toBe("\"Monitor\" 이용이 불가능합니다"); //metadata
+        expect(jsonData["Good      Morning"]).toBe("좋은 아침"); // multispaces
     });
     test("csample_test_es_CO", function() {
         expect.assertions(4);
@@ -132,22 +133,24 @@ describe("[integration] test the localization result of webos-c app", () => {
         expect(jsonData["TV Name"]).toBe("TV Name(en-US)");
     });
     test("csample_test_en_AU", function() {
-        expect.assertions(3);
+        expect.assertions(4);
         filePath = path.join(resourcePath, 'en/AU', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
         expect(jsonData["TV Name"]).toBe("Monitor Name"); // metadata - customInherit
+        expect(jsonData["OK"]).toBe("(common)OK"); // common - customInherit
     });
     test("csample_test_en_GB", function() {
-        expect.assertions(3);
+        expect.assertions(4);
         filePath = path.join(resourcePath, 'en/GB', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
         expect(jsonData["TV Name"]).toBe("Monitor Name");
+        expect(jsonData["OK"]).toBe("(common)OK");
     });
     test("csample_test_zxx", function() {
         expect.assertions(6);

--- a/packages/ilib-loctool-webos-c/test/integrationTest/common/en-GB.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/common/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>(common)OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
@@ -5,3 +5,4 @@ char *localized_string2 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "
 char *localized_string3 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Sound Out");
 char *localized_string4 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "NOT AVAILABLE");
 char *localized_string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "TV Name");
+char *localized_string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Good      Morning"); // multispaces

--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
@@ -39,6 +39,12 @@
             <target>이용이 불가능합니다</target>
         </segment>
     </unit>
+    <unit id="8">
+        <segment>
+          <source>Good      Morning</source>
+          <target>좋은 아침</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -1,7 +1,7 @@
 /*
  * CppApp.test.js - test the localization result in localize mode of webos-cpp app
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         }
     });
     test("cppsample_test_ko_KR", function() {
-        expect.assertions(6);
+        expect.assertions(7);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -104,10 +104,11 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(jsonData["No"]).toBe("아니오");
         expect(jsonData["Update"]).toBe("업데이트");
         expect(jsonData["Cancel"]).toBe("취소");
+        expect(jsonData["Good      Morning"]).toBe("좋은 아침");
         expect(jsonData["* This feature is applied once and only once when the TV is turned off."]).toBe("* 이 기능은 기기 전원이 꺼질 때 한번만 실행됩니다."); //metadata
     });
     test("cppsample_test_es_CO", function() {
-        expect.assertions(5);
+        expect.assertions(6);
         filePath = path.join(resourcePath, "es", fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -116,14 +117,18 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(jsonData["OK"]).toBe("Aceptar"); // common
         expect(jsonData["TV Information"]).toBe("Información del dispositivo");
         expect(jsonData["TV Name"]).toBe("Nombre del dispositivo(common)"); //metadata-common
+        expect(jsonData["Update"]).toBe("Actualizar");
     });
     test("cppsample_test_es_ES", function() {
-            expect.assertions(2);
-            filePath = path.join(resourcePath, 'es/ES', fileName);
-            expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
-            jsonData = pluginUtils.loadData(filePath);
-            expect(jsonData["TV Name"]).toBe("Nombre del dispositivo");
-        });
+        expect.assertions(5);
+        filePath = path.join(resourcePath, 'es/ES', fileName);
+        expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
+        jsonData = pluginUtils.loadData(filePath);
+        expect(Object.keys(jsonData).length).toBe(2);
+        expect(jsonData["Sound Out"]).toBe("Salida de sonido");
+        expect(jsonData["TV Name"]).toBe("Nombre del dispositivo");
+        expect(jsonData["Update"]).toBeUndefined(); // same as baseTranslation
+    });
     test("cppsample_test_en_US", function() {
         expect.assertions(3);
         filePath = path.join(resourcePath, fileName);
@@ -134,34 +139,38 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(jsonData["TV Name"]).toBe("TV Name(en-US)");
     });
     test("cppsample_test_en_AU", function() {
-        expect.assertions(3);
+        expect.assertions(4);
         filePath = path.join(resourcePath, "en/AU", fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
         expect(jsonData["TV Name"]).toBe("Device Name"); // metadata - customInherit
+        expect(jsonData["OK"]).toBe("(common)OK"); // common - customInherit
     });
     test("cppsample_test_en_GB", function() {
-        expect.assertions(2);
+        expect.assertions(3);
         filePath = path.join(resourcePath, "en/GB", fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
+        expect(jsonData["OK"]).toBe("(common)OK");
     });
     test("cppsample_test_zxx", function() {
-        expect.assertions(8);
+        expect.assertions(10);
         filePath = path.join(resourcePath, "zxx", fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
+        expect(Object.keys(jsonData).length).toBe(11);
         expect(jsonData["Cancel"]).toBe("[Çàñçëľ210]");
         expect(jsonData["No"]).toBe("[Ňõ0]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");
         expect(jsonData["Sound Out"]).toBe("[Šõüñð Øüţ43210]");
         expect(jsonData["Update"]).toBe("[Úþðàţë210]");
         expect(jsonData["Yes"]).toBe("[Ŷëš10]");
+        expect(jsonData["Good      Morning"]).toBe("[Ĝõõð      Mõŕñíñğ876543210]");
         expect(jsonData["* This feature is applied once and only once when the TV is turned off."]).toBe("[* Ťĥíš fëàţüŕë íš àþþľíëð õñçë àñð õñľÿ õñçë ŵĥëñ ţĥë ŤV íš ţüŕñëð õff.32109876543210]");
     });
   });

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * CppApp.test.js - test the localization result in generate mode of webos-cpp app
  *
- * Copyright (c) 2025 JEDLSoft
+ * Copyright (c) 2025-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
         jsonData = pluginUtils.loadData(filePath);
 
-        expect(Object.keys(jsonData).length).toBe(6);
+        expect(Object.keys(jsonData).length).toBe(7);
         expect(jsonData["No"]).toBe("아니오");
         expect(jsonData["Yes"]).toBe("예");
         expect(jsonData["Update"]).toBe("업데이트");

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/common/en-GB.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/common/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>(common)OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
@@ -8,3 +8,4 @@ std::string test7_label = ResBundleAdaptor::instance().getLocString("OK");
 std::string test8_label = ResBundleAdaptor::instance().getLocString("* This feature is applied once and only once when the TV is turned off.");
 std::string test9_label = ResBundleAdaptor::instance().getLocString("TV Information");
 std::string test10_label = ResBundleAdaptor::instance().getLocString("TV Name");
+std::string test11_label = ResBundleAdaptor::instance().getLocString("Good      Morning"); // multispaces

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-CO.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-CO.xliff
@@ -21,6 +21,12 @@
           <target>Información de TV</target>
         </segment>
       </unit>
+      <unit id="3">
+        <segment>
+          <source>Update</source>
+          <target>Actualizar</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-ES.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/es-ES.xliff
@@ -8,7 +8,7 @@
           <target>Salida de sonido</target>
         </segment>
       </unit>
-      <unit id="3">
+      <unit id="2">
         <mda:metadata>
           <mda:metaGroup category="device-type">
             <mda:meta type="Monitor">Nombre del monitor</mda:meta>
@@ -19,6 +19,12 @@
         <segment>
          <source>TV Name</source>
          <target>Nombre TV</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Update</source>
+          <target>Actualizar</target>
         </segment>
       </unit>
     </group>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
@@ -54,6 +54,12 @@
           <target>* 이 기능은 TV가 꺼질 때 한 번만 실행됩니다.</target>
         </segment>
       </unit>
+      <unit id="8">
+        <segment>
+          <source>Good Morning</source>
+          <target>좋은 아침</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-dart/DartFile.js
+++ b/packages/ilib-loctool-webos-dart/DartFile.js
@@ -1,7 +1,7 @@
 /*
  * DartFile.js - plugin to extract resources from a Dart source code file
  *
- * Copyright (c) 2023-2025, JEDLSoft
+ * Copyright (c) 2023-2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,10 +153,12 @@ DartFile.prototype.parse = function(data) {
             var commentResult = reI18nComment.exec(line);
             comment = (commentResult && commentResult.length > 1) ? commentResult[1] : undefined;
 
+            match = DartFile.unescapeString(match);
+
             var r = this.API.newResource({
                 resType: "string",
                 project: this.project.getProjectId(),
-                key: this.makeKey(match),
+                key: match,
                 sourceLocale: this.project.sourceLocale,
                 source: DartFile.unescapeString(match),
                 autoKey: true,

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -124,11 +124,16 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["TV Name"]).toBe("Nombre del Monitor"); // metadata - common
     });
     test("dartsample_test_es_ES", function() {
-        expect.assertions(2);
+        expect.assertions(7);
         filePath = path.join(resourcePath, 'es_ES.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
+        expect(Object.keys(jsonData).length).toBe(5);
+        expect(jsonData["App List"]).toBe("Lista de Aplicaciones");
+        expect(jsonData["Search"]).toBe("Buscar");
+        expect(jsonData["Back button"]).toBe("Botón regresar");
+        expect(jsonData["App Rating"]).toBe("Clasificación de Aplicación");
         expect(jsonData["TV Name"]).toBe("Nombre del monitor"); // metadata - localemap
     });
     test("dartsample_test_en_US", function() {
@@ -140,34 +145,39 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["Programme"]).toBe("Channel");
     });
     test("dartsample_test_en_GB", function() {
-        expect.assertions(2);
+        expect.assertions(4);
         filePath = path.join(resourcePath, 'en_GB.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
+        expect(jsonData["TV Name"]).toBe("Monitor Name"); // metadata
+        expect(jsonData["OK"]).toBe("(common)OK"); // common
     });
     test("dartsample_test_en_AU", function() {
-        expect.assertions(3);
+        expect.assertions(4);
         filePath = path.join(resourcePath, 'en_AU.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
         expect(jsonData["Programme"]).toBe("Programme");
-        expect(jsonData["TV Name"]).toBe("Monitor Name"); // metadata - localeInherit
+        expect(jsonData["TV Name"]).toBe("Monitor Name"); // metadata - customInherit
+        expect(jsonData["OK"]).toBe("(common)OK"); // common - customInherit
     });
     test("dartsample_test_zxx", function() {
-        expect.assertions(8);
+        expect.assertions(10);
         filePath = path.join(resourcePath, 'zxx.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
-        expect(Object.keys(jsonData).length).toBe(7);
+        expect(Object.keys(jsonData).length).toBe(9);
         expect(jsonData["App List"]).toBe("[Ãþþ Ľíšţ3210]");
         expect(jsonData["Back button"]).toBe("[ßàçķ büţţõñ543210]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");
         expect(jsonData["Search"]).toBe("[Šëàŕçĥ210]");
         expect(jsonData["Internal Speaker"]).toBe("[Ïñţëŕñàľ Šþëàķëŕ76543210]");
         expect(jsonData["TV Name"]).toBe("[ŤV Ňàmë3210]");
+        expect(jsonData["OK"]).toBe("[Øĸ0]");
+        expect(jsonData["Good      Morning"]).toBe("[Ĝõõð      Mõŕñíñğ876543210]");
     });
 });

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/common/en-GB.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/common/en-GB.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>(common)OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
@@ -5,3 +5,5 @@ translate("Programme");
 translate('App Rating', );
 translate('Internal Speaker', );
 translate('TV Name');
+translate('OK');
+translate('Good      Morning'); // multispaces

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-ES.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/es-ES.xliff
@@ -2,7 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
   <file id="sample-webos-dart_f1" original="sample-webos-dart">
     <group id="sample-webos-dart_g1" name="x-dart">
+      <unit id="1">
+        <segment>
+          <source>Search</source>
+          <target>Buscar</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>App List</source>
+          <target>Lista de Aplicaciones</target>
+        </segment>
+      </unit>
       <unit id="3">
+        <segment>
+          <source>Back button</source>
+          <target>Botón regresar</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>App Rating</source>
+          <target>Clasificación de Aplicación</target>
+        </segment>
+      </unit>
+      <unit id="5">
         <mda:metadata>
           <mda:metaGroup category="device-type">
             <mda:meta type="Monitor">Nombre del monitor</mda:meta>

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
@@ -8,3 +8,4 @@ msg7.reason = $L('Internal Speaker + Wired Headphones');
 msg8.reason = $L('TV Name');
 
 $L('%deviceType% Speaker'),
+$L('Good      Morning'); // multispaces -> cleaned up in the resource bundle

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
@@ -39,6 +39,12 @@
           <target>TV 스피커 + 유선 헤드폰</target>
         </segment>
       </unit>
+      <unit id="12">
+        <segment>
+          <source>Good Morning</source>
+          <target>좋은 아침</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,6 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0(grunt@1.6.2)
 
-  packages/ilib-xliff-webos/lib: {}
-
   packages/ilib-xliff-webos/src: {}
 
   packages/ilib-xliff-webos/test: {}


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
Fix a dart key extraction bug: do not compress source text when generating resource keys, matching C/C++ behavior.

Also update cross-plugin integration fixtures/tests to cover:
- multi-space source strings
- common locale inheritance from en-GB
- locale map / custom inherit expectations for C, C++, Dart

### Links
