### PR TITLE
webos-c/cpp/dart/js/common: Add universal lookup support to policy-based resolution

### DIFF
--- a/.changeset/afraid-kiwis-double.md
+++ b/.changeset/afraid-kiwis-double.md
@@ -1,0 +1,6 @@
+---
+"ilib-loctool-webos-common": patch
+---
+
+- buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step.
+- buildKey() handles the new "current" + "universal" entry using cleanHashKey.

--- a/.changeset/afraid-kiwis-double.md
+++ b/.changeset/afraid-kiwis-double.md
@@ -3,4 +3,4 @@
 ---
 
 - buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step.
-- buildKey() handles the new "current" + "universal" entry using cleanHashKey.
+- buildKey() handles the new "universal" entry

--- a/.changeset/heavy-bananas-tell.md
+++ b/.changeset/heavy-bananas-tell.md
@@ -5,7 +5,5 @@
 "ilib-loctool-webos-c": patch
 ---
 
-- Enable includeUniversal in each FileType.js.
-- Adde integration test data (xliff entries in both javascript/universal groups and common) to verify lookup priority:
-    self type > universal > common.
+- Enable includeUniversal in each FileType.js
 

--- a/.changeset/heavy-bananas-tell.md
+++ b/.changeset/heavy-bananas-tell.md
@@ -5,5 +5,7 @@
 "ilib-loctool-webos-c": patch
 ---
 
-- Enable includeUniversal in each FileType.js
+Add universal datatype fallback in policy-based translation lookup (self type → universal → common)
+- Enable `includeUniversal` option in each FileType.js to allow datatype-independent project-level fallback before common pool
+- Universal translations are shared across all file type handlers within the same project, unlike common which pulls from a separate shared project pool
 

--- a/.changeset/heavy-bananas-tell.md
+++ b/.changeset/heavy-bananas-tell.md
@@ -1,0 +1,11 @@
+---
+"ilib-loctool-webos-javascript": patch
+"ilib-loctool-webos-dart": patch
+"ilib-loctool-webos-cpp": patch
+"ilib-loctool-webos-c": patch
+---
+
+- Enable includeUniversal in each FileType.js.
+- Adde integration test data (xliff entries in both javascript/universal groups and common) to verify lookup priority:
+    self type > universal > common.
+

--- a/.changeset/heavy-worlds-win.md
+++ b/.changeset/heavy-worlds-win.md
@@ -1,0 +1,17 @@
+---
+"ilib-loctool-webos-dist": patch
+---
+
+ilib-loctool-webos-common:
+- buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step.
+- buildKey() handles the new "current" + "universal" entry using cleanHashKey.
+
+ilib-loctool-webos-javascript:
+ilib-loctool-webos-dart:
+ilib-loctool-webos-cpp:
+ilib-loctool-webos-c:
+- Enable includeUniversal in each FileType.js.
+- Adde integration test data (xliff entries in both javascript/universal groups and common) to verify lookup priority:
+    self type > universal > common.
+
+

--- a/.changeset/heavy-worlds-win.md
+++ b/.changeset/heavy-worlds-win.md
@@ -10,6 +10,8 @@ ilib-loctool-webos-javascript:
 ilib-loctool-webos-dart:
 ilib-loctool-webos-cpp:
 ilib-loctool-webos-c:
-- Enable includeUniversal in each FileType.js
+- Add universal datatype fallback in policy-based translation lookup (self type → universal → common)
+  - Enable `includeUniversal` option in each FileType.js to allow datatype-independent project-level fallback before common pool
+  - Universal translations are shared across all file type handlers within the same project, unlike common which pulls from a separate shared project pool
 
 

--- a/.changeset/heavy-worlds-win.md
+++ b/.changeset/heavy-worlds-win.md
@@ -3,15 +3,13 @@
 ---
 
 ilib-loctool-webos-common:
-- buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step.
-- buildKey() handles the new "current" + "universal" entry using cleanHashKey.
+- buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step
+- buildKey() handles the new "universal" entry
 
 ilib-loctool-webos-javascript:
 ilib-loctool-webos-dart:
 ilib-loctool-webos-cpp:
 ilib-loctool-webos-c:
-- Enable includeUniversal in each FileType.js.
-- Adde integration test data (xliff entries in both javascript/universal groups and common) to verify lookup priority:
-    self type > universal > common.
+- Enable includeUniversal in each FileType.js
 
 

--- a/packages/ilib-loctool-webos-c/CFileType.js
+++ b/packages/ilib-loctool-webos-c/CFileType.js
@@ -114,7 +114,7 @@ CFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations, { includeUniversal: true });
+    var resolver = buildResolver(db, translations, this.project.getProjectId(), { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-c/CFileType.js
+++ b/packages/ilib-loctool-webos-c/CFileType.js
@@ -114,7 +114,7 @@ CFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations);
+    var resolver = buildResolver(db, translations, { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         }
      });
     test("csample_test_ko_KR", function() {
-        expect.assertions(8);
+        expect.assertions(9);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -107,6 +107,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         expect(jsonData["Good      Morning"]).toBe("좋은 아침"); // multispaces
         expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
         expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
+        expect(jsonData["See   you   later"]).toBe("또 만나(common)"); // common cleanHashKey (multispaces in source)
     });
     test("csample_test_es_CO", function() {
         expect.assertions(4);

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CApp.test.js
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         }
      });
     test("csample_test_ko_KR", function() {
-        expect.assertions(6);
+        expect.assertions(8);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -105,6 +105,8 @@ describe("[integration] test the localization result of webos-c app", () => {
         expect(jsonData["Yes"]).toBe("예");
         expect(jsonData["NOT AVAILABLE"]).toBe("\"Monitor\" 이용이 불가능합니다"); //metadata
         expect(jsonData["Good      Morning"]).toBe("좋은 아침"); // multispaces
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
     });
     test("csample_test_es_CO", function() {
         expect.assertions(4);

--- a/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/CAppGenerate.test.js
@@ -74,7 +74,7 @@ describe("[integration] test the localization result of webos-c app", () => {
         }
     });
     test("csample_test_ko_KR_generate_mode", function() {
-        expect.assertions(6);
+        expect.assertions(8);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -84,6 +84,8 @@ describe("[integration] test the localization result of webos-c app", () => {
         expect(jsonData["Yes"]).toBe("예");
         expect(jsonData["Time Settings"]).toBe("시간 설정");
         expect(jsonData["NOT AVAILABLE"]).toBe("\"Monitor\" 이용이 불가능합니다");
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal
     });
     test("csample_test_en_AU_generate_mode", function() {
         expect.assertions(3);

--- a/packages/ilib-loctool-webos-c/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(common)</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-c/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/common/ko-KR.xliff
@@ -8,6 +8,12 @@
           <target>재시도(common)</target>
         </segment>
       </unit>
+      <unit id="2">
+        <segment>
+          <source>See you later</source>
+          <target>또 만나(common)</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
@@ -6,3 +6,5 @@ char *localized_string3 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "
 char *localized_string4 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "NOT AVAILABLE");
 char *localized_string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "TV Name");
 char *localized_string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Good      Morning"); // multispaces
+char *localized_string7 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "EXIT APP");
+char *localized_string8 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "RETRY");

--- a/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/src/test.c
@@ -8,3 +8,4 @@ char *localized_string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "
 char *localized_string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Good      Morning"); // multispaces
 char *localized_string7 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "EXIT APP");
 char *localized_string8 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "RETRY");
+char *localized_string9 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "See   you   later"); // multispaces - common cleanHashKey

--- a/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-c/test/integrationTest/xliffs/ko-KR.xliff
@@ -46,5 +46,19 @@
         </segment>
       </unit>
     </group>
+    <group id="sample-webos-c_g2" name="universal">
+      <unit id="101">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 종료</target>
+        </segment>
+      </unit>
+      <unit id="102">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(universal)</target>
+        </segment>
+      </unit>
+    </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-common/DB_LOOKUP_FLOW.md
+++ b/packages/ilib-loctool-webos-common/DB_LOOKUP_FLOW.md
@@ -15,6 +15,9 @@ resolution engine provided by this package.
 
 ## 1. Full lookup chain per plugin
 
+> This section describes the original (pre-refactor) lookup behavior as
+> implemented in each plugin's `write()` method.
+
 ### 1-1. JS / C / Cpp (identical structure)
 
 ```
@@ -90,10 +93,10 @@ package:
 ### Call sequence inside `write()`
 
 ```
-resolver = buildResolver(db, translations, options?)
+resolver = buildResolver(db, translations, projectName, options?)
     → detectCommonData(translations)      // internal, no side effects
-    → buildPolicy(options)                // declarative policy array
-    → makeLookupParams factory            // captures db, policy, common data
+    → buildPolicy(projectName, common, options)  // concrete values in entries
+    → makeLookupParams factory            // captures db and policy
     → returns { db, policy, makeLookupParams }
 
 // per resource, per locale:
@@ -105,25 +108,37 @@ resolveTranslation({ resolver, resFileType, newres, res, locale, ... })
     → dedup check + dispatch (addResource / addNewResource)
 ```
 
-### `buildResolver(db, translations, options?)`
+### `buildResolver(db, translations, projectName, options?)`
 
 Creates a resolver context with no side effects. Internally:
 1. Calls `detectCommonData(translations)` — returns `{ commonPrjName, commonPrjType }`
-2. Calls `buildPolicy(options)` — returns the policy array
-3. Builds a `makeLookupParams(resource, locale)` factory capturing all the above
+2. Calls `buildPolicy(projectName, common, options)` — returns the policy array with concrete values
+3. Builds a `makeLookupParams(resource, locale)` factory capturing db and policy
 
-### `buildPolicy(options?)` — current policy array
+### `buildPolicy(projectName, common, options?)` — policy array
 
-| Step | project | keyType  | datatype |
-|------|---------|----------|----------|
-| 0    | common  | hashKey  | common   |
+Policy entries contain concrete project names and datatypes resolved at
+build time. No symbolic values like "self" or "common" — what you see in
+the array is exactly what gets queried.
 
-`buildKey` returns `undefined` when `commonPrjName`/`commonPrjType` are
-absent (i.e. no common project was detected), causing that step to be
-skipped automatically — no separate flag needed.
+Default (no `includeUniversal`, common data present):
 
-The `options` parameter is reserved for plugin-specific policy configuration
-(e.g. additional fallback steps). Currently unused.
+| Step | project | datatype |
+|------|---------|----------|
+| 0    | (commonPrjName) | (commonPrjType) |
+
+With `options.includeUniversal = true` and common data present:
+
+| Step | project | datatype |
+|------|---------|----------|
+| 0    | (projectName) | universal |
+| 1    | (commonPrjName) | (commonPrjType) |
+
+When common data is absent (`detectCommonData` found nothing), the common
+step is omitted entirely — no entry is added to the array.
+
+The `options.includeUniversal` flag prepends a universal (datatype-independent)
+lookup step using the provided `projectName` before falling back to common.
 
 ### `lookupByPolicy(params, callback)`
 
@@ -194,10 +209,24 @@ Key params controlling behavior:
 | Lookup target | Function | Notes |
 |---------------|----------|-------|
 | locale direct | `res.cleanHashKeyForTranslation(locale)` | Normalizes whitespace (cleanHashKey) |
-| common project | `ResourceString.hashKey(commonPrjName, locale, key, commonPrjType, flavor)` | No whitespace normalization |
+| universal | `ResourceString.cleanHashKey(projectName, locale, key, "universal", flavor)` | Own project, datatype-independent |
+| common | `ResourceString.cleanHashKey(commonPrjName, locale, key, commonPrjType, flavor)` | Shared common project pool |
 
-`cleanHashKey` (multi-space normalized) vs `hashKey` (raw): direct lookups
-use the clean variant; common lookups use the raw variant.
+`buildKey()` has no branching — it always calls `cleanHashKey()` with the
+project and datatype stored in the policy entry.
+
+### Why `cleanHashKey` instead of `hashKey`
+
+The original implementation used `ResourceString.hashKey()` for common/policy
+lookups. The refactored version uses `cleanHashKey()` uniformly. The
+difference is whitespace normalization: `cleanHashKey` collapses consecutive
+whitespace into a single space before hashing.
+
+In practice this only matters for JavaScript sources — C, C++, and Dart
+extractors preserve whitespace in keys as-is, so `hashKey` and `cleanHashKey`
+produce identical results for those languages. Using `cleanHashKey`
+consistently eliminates a subtle mismatch where JS source keys with
+irregular whitespace could fail to match their DB entries via `hashKey`.
 
 ---
 
@@ -212,10 +241,9 @@ the source before being passed to `addResource`.
 
 ### Common step gating
 
-The `isCommonDataLoaded` flag has been removed. `buildKey` returns
-`undefined` when `commonPrjName`/`commonPrjType` are absent, which is only
-the case when `detectCommonData` found no common project — equivalent guard,
-no extra flag.
+Common step gating happens at `buildPolicy()` time: when `detectCommonData`
+returns no common project, no common entry is added to the policy array.
+`lookupByPolicy()` simply iterates what it receives — no runtime check needed.
 
 ### Dart baseTranslation policy (intentional)
 
@@ -233,7 +261,10 @@ lookup path produces the final translation.
 
 ### Extensibility via policy options
 
-To add a new fallback step (e.g. brand project lookup):
-1. Add an entry in `buildPolicy(options)` conditionally based on `options`
-2. Add a matching key-building branch in `buildKey()`
-3. No changes needed in `lookupByPolicy()` or `resolveTranslation()`
+To add a new fallback step:
+1. Pass the new project/datatype info to `buildResolver()` / `buildPolicy()`
+2. Add a new entry with concrete project/datatype values in `buildPolicy()`
+3. No changes needed in `buildKey()`, `lookupByPolicy()`, or `resolveTranslation()`
+
+`buildKey()` is a single-line function with no branching — new policy
+entries work automatically.

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -25,7 +25,7 @@ var ResourceString = require("loctool/lib/ResourceString.js");
  * which causes lookupByPolicy to silently skip that step.
  *
  * Supported entry branches:
- *   - "current" + datatype "universal": locale-independent translation stored
+ *   - "current" + datatype "universal": datatype-independent translation stored
  *     under the *current* project. The key is built from the resource's own
  *     project (resource.getProject()); the step is skipped when that is absent.
  *   - "common": translation stored in the shared common project pool. Requires
@@ -77,11 +77,11 @@ function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
  * higher-priority entries earlier in the array:
  *
  *   priority high → low:
- *     universal (current project, all locales) → common (shared pool)
+ *     universal (current project, datatype-independent) → common (shared pool)
  *
  * Current options:
  *   - options.includeUniversal {boolean} — when true, prepends a "universal"
- *     step that looks up a locale-independent translation within the current
+ *     step that looks up a datatype-independent translation within the current
  *     project before falling back to the common project pool.
  *
  * To add a new fallback step:

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -21,49 +21,20 @@ var ResourceString = require("loctool/lib/ResourceString.js");
 
 /**
  * Build the DB key for a given resource, locale, and policy entry.
- * Returns undefined if the key cannot be built (e.g. missing project name),
- * which causes lookupByPolicy to silently skip that step.
  *
- * Supported entry branches:
- *   - "current" + datatype "universal": datatype-independent translation stored
- *     under the *current* project. The key is built from the resource's own
- *     project (resource.getProject()); the step is skipped when that is absent.
- *   - "common": translation stored in the shared common project pool. Requires
- *     commonPrjName/commonPrjType (captured at buildResolver() time); the step
- *     is skipped when either is missing.
- *
- * Key-builder choice: the "universal" branch uses ResourceString.cleanHashKey()
- * while the "common" branch uses ResourceString.hashKey(). Both keys are later
- * queried via db.getResourceByCleanHashKey() in lookupByPolicy() — the common
- * branch intentionally mirrors the pre-refactor behavior, where a hashKey()
- * value was passed to getResourceByCleanHashKey(). Do not "normalize" the two
- * builders to match without verifying against the DB key format.
- *
- * When adding a new policy step to buildPolicy(), add a matching branch here
- * that handles the new entry.project value. A missing branch means lookupByPolicy
- * returns undefined for that step even when the entry is present.
+ * Each policy entry contains the concrete project name and datatype resolved
+ * at buildPolicy() time. This function simply delegates to
+ * ResourceString.cleanHashKey() without branching.
  *
  * @param {Resource} resource
  * @param {string} locale
- * @param {Object} entry - policy entry from buildPolicy()
- * @param {string} [commonPrjName]
- * @param {string} [commonPrjType]
- * @returns {string|undefined}
+ * @param {Object} entry - policy entry from buildPolicy(); must have .project and .datatype
+ * @returns {string}
  */
-function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
-
-    if (entry.project === "current" && entry.datatype === "universal") {
-        var project = resource.getProject && resource.getProject();
-        if (!project) return undefined;
-        return ResourceString.cleanHashKey(project, locale, resource.getKey(), entry.datatype, resource.getFlavor());
-    }
-
-    if (entry.project === "common") {
-        if (!commonPrjName || !commonPrjType) return undefined;
-        return ResourceString.hashKey(commonPrjName, locale, resource.getKey(), commonPrjType, resource.getFlavor());
-    }
-
-    return undefined;
+function buildKey(resource, locale, entry) {
+    return ResourceString.cleanHashKey(
+        entry.project, locale, resource.getKey(), entry.datatype, resource.getFlavor()
+    );
 }
 
 /**
@@ -77,41 +48,36 @@ function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
  * higher-priority entries earlier in the array:
  *
  *   priority high → low:
- *     universal (current project, datatype-independent) → common (shared pool)
+ *     universal (own project, datatype-independent) → common (shared pool)
  *
- * Current options:
- *   - options.includeUniversal {boolean} — when true, prepends a "universal"
- *     step that looks up a datatype-independent translation within the current
- *     project before falling back to the common project pool.
+ * Concrete project names and datatypes are resolved at policy-creation time
+ * and stored directly in the entry objects. This eliminates runtime branching
+ * in buildKey() and makes the policy array self-describing — you can inspect
+ * it to see exactly which DB keys will be queried.
  *
- * To add a new fallback step:
- *   1. Add a new entry object (see the "universal" entry above as a reference).
- *   2. Add a matching branch in buildKey() (see the existing
- *      `if (entry.project === "current")` and `if (entry.project === "common")` branches).
- *   3. If the step needs extra context fields, add them to the makeLookupParams factory in buildResolver().
- *   4. Consider priority: insert the entry at the appropriate position in the
- *      array so that more specific lookups are tried before broader ones.
- *
+ * @param {string} projectName - the current project name (e.g. from project.getProjectId())
+ * @param {{commonPrjName: (string|undefined), commonPrjType: (string|undefined)}} common
+ *   - detected common project data from detectCommonData()
  * @param {Object} [options] - plugin-specific policy configuration
- * @param {boolean} [options.includeUniversal] - prepend universal (current project) lookup step
- * @returns {Array<{keyType: string, project: string, datatype: string}>}
+ * @param {boolean} [options.includeUniversal] - prepend universal (own project) lookup step
+ * @returns {Array<{project: string, datatype: string}>}
  */
-function buildPolicy(options) {
+function buildPolicy(projectName, common, options) {
     var policy = [];
 
-    if (options && options.includeUniversal) {
+    if (options && options.includeUniversal && projectName) {
         policy.push({
-            keyType: "hashKey",
-            project: "current",
+            project: projectName,
             datatype: "universal"
         });
     }
 
-    policy.push({
-        keyType: "hashKey",
-        project: "common",
-        datatype: "common"
-    });
+    if (common && common.commonPrjName && common.commonPrjType) {
+        policy.push({
+            project: common.commonPrjName,
+            datatype: common.commonPrjType
+        });
+    }
 
     return policy;
 }
@@ -127,8 +93,6 @@ function buildPolicy(options) {
  * @param {Resource} params.resource            - source resource being looked up
  * @param {string}   params.locale              - target locale
  * @param {Array}    params.policy              - policy array from buildPolicy()
- * @param {string}   [params.commonPrjName]     - common project name (e.g. "common")
- * @param {string}   [params.commonPrjType]     - common project datatype
  * @param {number}   [params.startIndex=0]      - internal recursion index; callers omit this
  * @param {function(Resource|undefined): void} callback
  */
@@ -142,12 +106,7 @@ function lookupByPolicy(params, callback) {
     }
 
     var entry = policy[step];
-
-    var key = buildKey(params.resource, params.locale, entry, params.commonPrjName, params.commonPrjType);
-    if (!key) {
-        lookupByPolicy(Object.assign({}, params, { startIndex: step + 1 }), callback);
-        return;
-    }
+    var key = buildKey(params.resource, params.locale, entry);
 
     params.db.getResourceByCleanHashKey(key, function(err, translated) {
         if (translated) {

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -37,6 +37,12 @@ var ResourceString = require("loctool/lib/ResourceString.js");
  */
 function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
 
+    if (entry.project === "current" && entry.datatype === "universal") {
+        var project = resource.getProject && resource.getProject();
+        if (!project) return undefined;
+        return ResourceString.cleanHashKey(project, locale, resource.getKey(), entry.datatype, resource.getFlavor());
+    }
+
     if (entry.project === "common") {
         if (!commonPrjName || !commonPrjType) return undefined;
         return ResourceString.hashKey(commonPrjName, locale, resource.getKey(), commonPrjType, resource.getFlavor());
@@ -61,6 +67,14 @@ function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
  */
 function buildPolicy(options) {
     var policy = [];
+
+    if (options && options.includeUniversal) {
+        policy.push({
+            keyType: "hashKey",
+            project: "current",
+            datatype: "universal"
+        });
+    }
 
     policy.push({
         keyType: "hashKey",

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -57,12 +57,28 @@ function buildKey(resource, locale, entry, commonPrjName, commonPrjType) {
  * Step 0 (locale direct via cleanHashKeyForTranslation) is NOT included here —
  * callers perform that lookup themselves, then call lookupByPolicy on miss.
  *
- * To add a new fallback step:
- *   1. Push a new entry object here (e.g. { keyType: "hashKey", project: "brand", datatype: "..." }).
- *   2. Add a matching `if (entry.project === "brand")` branch in buildKey() above.
- *   3. If the step needs extra context fields, add them to the makeLookupParams factory in buildResolver().
+ * Policy steps are tried in array order (index 0 first). The first hit wins
+ * and terminates the lookup. When adding new steps, place more specific /
+ * higher-priority entries earlier in the array:
  *
- * @param {Object} [options] - reserved for future step configuration; currently unused
+ *   priority high → low:
+ *     universal (current project, all locales) → common (shared pool)
+ *
+ * Current options:
+ *   - options.includeUniversal {boolean} — when true, prepends a "universal"
+ *     step that looks up a locale-independent translation within the current
+ *     project before falling back to the common project pool.
+ *
+ * To add a new fallback step:
+ *   1. Add a new entry object (see the "universal" entry above as a reference).
+ *   2. Add a matching branch in buildKey() (see the existing
+ *      `if (entry.project === "current")` and `if (entry.project === "common")` branches).
+ *   3. If the step needs extra context fields, add them to the makeLookupParams factory in buildResolver().
+ *   4. Consider priority: insert the entry at the appropriate position in the
+ *      array so that more specific lookups are tried before broader ones.
+ *
+ * @param {Object} [options] - plugin-specific policy configuration
+ * @param {boolean} [options.includeUniversal] - prepend universal (current project) lookup step
  * @returns {Array<{keyType: string, project: string, datatype: string}>}
  */
 function buildPolicy(options) {

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -24,6 +24,21 @@ var ResourceString = require("loctool/lib/ResourceString.js");
  * Returns undefined if the key cannot be built (e.g. missing project name),
  * which causes lookupByPolicy to silently skip that step.
  *
+ * Supported entry branches:
+ *   - "current" + datatype "universal": locale-independent translation stored
+ *     under the *current* project. The key is built from the resource's own
+ *     project (resource.getProject()); the step is skipped when that is absent.
+ *   - "common": translation stored in the shared common project pool. Requires
+ *     commonPrjName/commonPrjType (captured at buildResolver() time); the step
+ *     is skipped when either is missing.
+ *
+ * Key-builder choice: the "universal" branch uses ResourceString.cleanHashKey()
+ * while the "common" branch uses ResourceString.hashKey(). Both keys are later
+ * queried via db.getResourceByCleanHashKey() in lookupByPolicy() — the common
+ * branch intentionally mirrors the pre-refactor behavior, where a hashKey()
+ * value was passed to getResourceByCleanHashKey(). Do not "normalize" the two
+ * builders to match without verifying against the DB key format.
+ *
  * When adding a new policy step to buildPolicy(), add a matching branch here
  * that handles the new entry.project value. A missing branch means lookupByPolicy
  * returns undefined for that step even when the entry is present.

--- a/packages/ilib-loctool-webos-common/lookupByPolicy.js
+++ b/packages/ilib-loctool-webos-common/lookupByPolicy.js
@@ -93,28 +93,28 @@ function buildPolicy(projectName, common, options) {
  * @param {Resource} params.resource            - source resource being looked up
  * @param {string}   params.locale              - target locale
  * @param {Array}    params.policy              - policy array from buildPolicy()
- * @param {number}   [params.startIndex=0]      - internal recursion index; callers omit this
  * @param {function(Resource|undefined): void} callback
  */
 function lookupByPolicy(params, callback) {
-    var step = typeof params.startIndex === "number" ? params.startIndex : 0;
     var policy = params.policy;
 
-    if (step >= policy.length) {
-        callback(undefined);
-        return;
+    function next(step) {
+        if (step >= policy.length) {
+            callback(undefined);
+            return;
+        }
+
+        var key = buildKey(params.resource, params.locale, policy[step]);
+        params.db.getResourceByCleanHashKey(key, function(err, translated) {
+            if (translated) {
+                callback(translated);
+            } else {
+                next(step + 1);
+            }
+        });
     }
 
-    var entry = policy[step];
-    var key = buildKey(params.resource, params.locale, entry);
-
-    params.db.getResourceByCleanHashKey(key, function(err, translated) {
-        if (translated) {
-            callback(translated);
-        } else {
-            lookupByPolicy(Object.assign({}, params, { startIndex: step + 1 }), callback);
-        }
-    });
+    next(0);
 }
 
 module.exports = {

--- a/packages/ilib-loctool-webos-common/test/lookupByPolicy.test.js
+++ b/packages/ilib-loctool-webos-common/test/lookupByPolicy.test.js
@@ -52,6 +52,27 @@ describe("buildPolicy", function() {
         });
         expect(policy[0].needsCommonData).toBeUndefined();
     });
+
+    test("includeUniversal option adds universal step before common", function() {
+        var policy = buildPolicy({ includeUniversal: true });
+        expect(policy).toHaveLength(2);
+        expect(policy[0]).toMatchObject({
+            keyType: "hashKey",
+            project: "current",
+            datatype: "universal"
+        });
+        expect(policy[1]).toMatchObject({
+            keyType: "hashKey",
+            project: "common",
+            datatype: "common"
+        });
+    });
+
+    test("includeUniversal false does not add universal step", function() {
+        var policy = buildPolicy({ includeUniversal: false });
+        expect(policy).toHaveLength(1);
+        expect(policy[0].project).toBe("common");
+    });
 });
 
 // ── lookupByPolicy ────────────────────────────────────────────────────────────
@@ -120,6 +141,112 @@ describe("lookupByPolicy", function() {
         }, function(result) {
             expect(result).toBeUndefined();
             expect(db.getResourceByCleanHashKey).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    test("universal step hit returns result before reaching common", function(done) {
+        var universalKey = ResourceString.cleanHashKey("myapp", "ko-KR", "hello", "universal", undefined);
+        var fakeUniversal = { target: "유니버설 안녕" };
+        var db = makeDb({ [universalKey]: fakeUniversal });
+
+        var policy = buildPolicy({ includeUniversal: true });
+        lookupByPolicy({
+            db: db,
+            resource: makeResource("myapp", "hello"),
+            locale: "ko-KR",
+            policy: policy,
+            commonPrjName: "common",
+            commonPrjType: "x-json"
+        }, function(result) {
+            expect(result).toBe(fakeUniversal);
+            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
+            done();
+        });
+    });
+
+    test("universal step miss falls through to common step", function(done) {
+        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "x-json", undefined);
+        var fakeCommon = { target: "공통 안녕" };
+        var db = makeDb({ [commonKey]: fakeCommon });
+
+        var policy = buildPolicy({ includeUniversal: true });
+        lookupByPolicy({
+            db: db,
+            resource: makeResource("myapp", "hello"),
+            locale: "ko-KR",
+            policy: policy,
+            commonPrjName: "common",
+            commonPrjType: "x-json"
+        }, function(result) {
+            expect(result).toBe(fakeCommon);
+            // first call for universal (miss), second call for common (hit)
+            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(2);
+            done();
+        });
+    });
+
+    test("universal step skipped when resource has no getProject", function(done) {
+        var resourceNoProject = {
+            getKey: function() { return "hello"; },
+            getFlavor: function() { return undefined; }
+            // getProject intentionally missing
+        };
+        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "x-json", undefined);
+        var fakeCommon = { target: "공통 안녕" };
+        var db = makeDb({ [commonKey]: fakeCommon });
+
+        var policy = buildPolicy({ includeUniversal: true });
+        lookupByPolicy({
+            db: db,
+            resource: resourceNoProject,
+            locale: "ko-KR",
+            policy: policy,
+            commonPrjName: "common",
+            commonPrjType: "x-json"
+        }, function(result) {
+            expect(result).toBe(fakeCommon);
+            // universal skipped (no project), only common looked up
+            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
+            done();
+        });
+    });
+
+    test("universal step skipped when getProject returns falsy", function(done) {
+        var resourceNullProject = {
+            getProject: function() { return undefined; },
+            getKey: function() { return "hello"; },
+            getFlavor: function() { return undefined; }
+        };
+        var db = makeDb({});
+
+        var policy = buildPolicy({ includeUniversal: true });
+        lookupByPolicy({
+            db: db,
+            resource: resourceNullProject,
+            locale: "ko-KR",
+            policy: policy
+            // no commonPrjName either, so both steps skip
+        }, function(result) {
+            expect(result).toBeUndefined();
+            expect(db.getResourceByCleanHashKey).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    test("universal step with flavor generates correct key", function(done) {
+        var universalKey = ResourceString.cleanHashKey("myapp", "ko-KR", "hello", "universal", "tv");
+        var fakeUniversal = { target: "TV 유니버설 안녕" };
+        var db = makeDb({ [universalKey]: fakeUniversal });
+
+        var policy = buildPolicy({ includeUniversal: true });
+        lookupByPolicy({
+            db: db,
+            resource: makeResource("myapp", "hello", "tv"),
+            locale: "ko-KR",
+            policy: policy
+        }, function(result) {
+            expect(result).toBe(fakeUniversal);
             done();
         });
     });

--- a/packages/ilib-loctool-webos-common/test/lookupByPolicy.test.js
+++ b/packages/ilib-loctool-webos-common/test/lookupByPolicy.test.js
@@ -19,12 +19,10 @@
 
 var { buildPolicy, lookupByPolicy } = require("../lookupByPolicy.js");
 var ResourceString = require("loctool/lib/ResourceString.js");
-var Utils = require("loctool/lib/utils.js");
 
 // Minimal resource mock — only the fields lookupByPolicy needs
-function makeResource(project, key, flavor) {
+function makeResource(key, flavor) {
     return {
-        getProject: function() { return project; },
         getKey: function() { return key; },
         getFlavor: function() { return flavor || undefined; }
     };
@@ -42,36 +40,58 @@ function makeDb(hitMap) {
 // ── buildPolicy ──────────────────────────────────────────────────────────────
 
 describe("buildPolicy", function() {
-    test("default (no options) returns common-only policy", function() {
-        var policy = buildPolicy();
+    test("returns common step when common data is provided", function() {
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common);
         expect(policy).toHaveLength(1);
         expect(policy[0]).toMatchObject({
-            keyType: "hashKey",
             project: "common",
-            datatype: "common"
+            datatype: "x-json"
         });
-        expect(policy[0].needsCommonData).toBeUndefined();
     });
 
-    test("includeUniversal option adds universal step before common", function() {
-        var policy = buildPolicy({ includeUniversal: true });
+    test("returns empty policy when common data is absent", function() {
+        var common = { commonPrjName: undefined, commonPrjType: undefined };
+        var policy = buildPolicy("myapp", common);
+        expect(policy).toHaveLength(0);
+    });
+
+    test("includeUniversal prepends universal step with actual project name", function() {
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
         expect(policy).toHaveLength(2);
         expect(policy[0]).toMatchObject({
-            keyType: "hashKey",
-            project: "current",
+            project: "myapp",
             datatype: "universal"
         });
         expect(policy[1]).toMatchObject({
-            keyType: "hashKey",
             project: "common",
-            datatype: "common"
+            datatype: "x-json"
         });
     });
 
-    test("includeUniversal false does not add universal step", function() {
-        var policy = buildPolicy({ includeUniversal: false });
+    test("includeUniversal without projectName skips universal step", function() {
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy(undefined, common, { includeUniversal: true });
         expect(policy).toHaveLength(1);
         expect(policy[0].project).toBe("common");
+    });
+
+    test("includeUniversal false does not add universal step", function() {
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: false });
+        expect(policy).toHaveLength(1);
+        expect(policy[0].project).toBe("common");
+    });
+
+    test("no common data with includeUniversal returns universal-only policy", function() {
+        var common = { commonPrjName: undefined, commonPrjType: undefined };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
+        expect(policy).toHaveLength(1);
+        expect(policy[0]).toMatchObject({
+            project: "myapp",
+            datatype: "universal"
+        });
     });
 });
 
@@ -82,7 +102,7 @@ describe("lookupByPolicy", function() {
         var db = makeDb({});
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello"),
+            resource: makeResource("hello"),
             locale: "ko-KR",
             policy: []
         }, function(result) {
@@ -92,36 +112,18 @@ describe("lookupByPolicy", function() {
         });
     });
 
-    test("missing commonPrjName/Type skips common step without DB call", function(done) {
-        var db = makeDb({});
-        var policy = buildPolicy();
-        lookupByPolicy({
-            db: db,
-            resource: makeResource("myapp", "hello"),
-            locale: "ko-KR",
-            policy: policy
-            // commonPrjName/commonPrjType absent — buildKey returns undefined → skip
-        }, function(result) {
-            expect(result).toBeUndefined();
-            expect(db.getResourceByCleanHashKey).not.toHaveBeenCalled();
-            done();
-        });
-    });
-
     test("common step hit returns result", function(done) {
-        var ResourceString = require("loctool/lib/ResourceString.js");
-        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "x-json", undefined);
+        var commonKey = ResourceString.cleanHashKey("common", "ko-KR", "hello", "x-json", undefined);
         var fakeCommon = { target: "공통 안녕" };
         var db = makeDb({ [commonKey]: fakeCommon });
 
-        var policy = buildPolicy();
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common);
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello"),
+            resource: makeResource("hello"),
             locale: "ko-KR",
-            policy: policy,
-            commonPrjName: "common",
-            commonPrjType: "x-json"
+            policy: policy
         }, function(result) {
             expect(result).toBe(fakeCommon);
             expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
@@ -129,18 +131,18 @@ describe("lookupByPolicy", function() {
         });
     });
 
-    test("missing commonPrjName skips common step", function(done) {
+    test("common step miss returns undefined", function(done) {
         var db = makeDb({});
-        var policy = buildPolicy();
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common);
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello"),
+            resource: makeResource("hello"),
             locale: "ko-KR",
             policy: policy
-            // commonPrjName and commonPrjType intentionally missing
         }, function(result) {
             expect(result).toBeUndefined();
-            expect(db.getResourceByCleanHashKey).not.toHaveBeenCalled();
+            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
             done();
         });
     });
@@ -150,14 +152,13 @@ describe("lookupByPolicy", function() {
         var fakeUniversal = { target: "유니버설 안녕" };
         var db = makeDb({ [universalKey]: fakeUniversal });
 
-        var policy = buildPolicy({ includeUniversal: true });
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello"),
+            resource: makeResource("hello"),
             locale: "ko-KR",
-            policy: policy,
-            commonPrjName: "common",
-            commonPrjType: "x-json"
+            policy: policy
         }, function(result) {
             expect(result).toBe(fakeUniversal);
             expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
@@ -166,18 +167,17 @@ describe("lookupByPolicy", function() {
     });
 
     test("universal step miss falls through to common step", function(done) {
-        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "x-json", undefined);
+        var commonKey = ResourceString.cleanHashKey("common", "ko-KR", "hello", "x-json", undefined);
         var fakeCommon = { target: "공통 안녕" };
         var db = makeDb({ [commonKey]: fakeCommon });
 
-        var policy = buildPolicy({ includeUniversal: true });
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello"),
+            resource: makeResource("hello"),
             locale: "ko-KR",
-            policy: policy,
-            commonPrjName: "common",
-            commonPrjType: "x-json"
+            policy: policy
         }, function(result) {
             expect(result).toBe(fakeCommon);
             // first call for universal (miss), second call for common (hit)
@@ -186,63 +186,32 @@ describe("lookupByPolicy", function() {
         });
     });
 
-    test("universal step skipped when resource has no getProject", function(done) {
-        var resourceNoProject = {
-            getKey: function() { return "hello"; },
-            getFlavor: function() { return undefined; }
-            // getProject intentionally missing
-        };
-        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "x-json", undefined);
-        var fakeCommon = { target: "공통 안녕" };
-        var db = makeDb({ [commonKey]: fakeCommon });
-
-        var policy = buildPolicy({ includeUniversal: true });
-        lookupByPolicy({
-            db: db,
-            resource: resourceNoProject,
-            locale: "ko-KR",
-            policy: policy,
-            commonPrjName: "common",
-            commonPrjType: "x-json"
-        }, function(result) {
-            expect(result).toBe(fakeCommon);
-            // universal skipped (no project), only common looked up
-            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(1);
-            done();
-        });
-    });
-
-    test("universal step skipped when getProject returns falsy", function(done) {
-        var resourceNullProject = {
-            getProject: function() { return undefined; },
-            getKey: function() { return "hello"; },
-            getFlavor: function() { return undefined; }
-        };
+    test("all steps miss returns undefined", function(done) {
         var db = makeDb({});
-
-        var policy = buildPolicy({ includeUniversal: true });
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
         lookupByPolicy({
             db: db,
-            resource: resourceNullProject,
+            resource: makeResource("hello"),
             locale: "ko-KR",
             policy: policy
-            // no commonPrjName either, so both steps skip
         }, function(result) {
             expect(result).toBeUndefined();
-            expect(db.getResourceByCleanHashKey).not.toHaveBeenCalled();
+            expect(db.getResourceByCleanHashKey).toHaveBeenCalledTimes(2);
             done();
         });
     });
 
-    test("universal step with flavor generates correct key", function(done) {
+    test("flavor is included in generated key", function(done) {
         var universalKey = ResourceString.cleanHashKey("myapp", "ko-KR", "hello", "universal", "tv");
         var fakeUniversal = { target: "TV 유니버설 안녕" };
         var db = makeDb({ [universalKey]: fakeUniversal });
 
-        var policy = buildPolicy({ includeUniversal: true });
+        var common = { commonPrjName: "common", commonPrjType: "x-json" };
+        var policy = buildPolicy("myapp", common, { includeUniversal: true });
         lookupByPolicy({
             db: db,
-            resource: makeResource("myapp", "hello", "tv"),
+            resource: makeResource("hello", "tv"),
             locale: "ko-KR",
             policy: policy
         }, function(result) {
@@ -250,8 +219,4 @@ describe("lookupByPolicy", function() {
             done();
         });
     });
-
 });
-
-
-

--- a/packages/ilib-loctool-webos-common/test/translationResolver.test.js
+++ b/packages/ilib-loctool-webos-common/test/translationResolver.test.js
@@ -18,7 +18,6 @@
  */
 
 var { buildResolver, resolveTranslation } = require("../translationResolver.js");
-var { buildPolicy } = require("../lookupByPolicy.js");
 var TranslationSet = require("loctool/lib/TranslationSet.js");
 var ResourceString = require("loctool/lib/ResourceString.js");
 var Utils = require("loctool/lib/utils.js");
@@ -150,19 +149,19 @@ function makeCommonTs() {
 // ── buildResolver ────────────────────────────────────────────────────────────
 
 describe("buildResolver", function() {
-    test("translations undefined — no common data in lookup params", function() {
+    test("translations undefined — empty policy (no common data)", function() {
         var db = makeDb({});
-        var resolver = buildResolver(db, undefined);
+        var resolver = buildResolver(db, undefined, "myapp");
         expect(resolver.db).toBe(db);
-        expect(resolver.policy).toEqual(buildPolicy());
+        expect(resolver.policy).toEqual([]);
         expect(typeof resolver.makeLookupParams).toBe("function");
 
         var params = resolver.makeLookupParams(makeTestResource("a", "A"), "ko-KR");
-        expect(params.commonPrjName).toBeUndefined();
-        expect(params.commonPrjType).toBeUndefined();
+        expect(params.db).toBe(db);
+        expect(params.policy).toEqual([]);
     });
 
-    test("no common project in translations — no common data in lookup params", function() {
+    test("no common project in translations — empty policy", function() {
         var ts = new TranslationSet();
         ts.add(new ResourceString({
             project: "myapp",
@@ -173,38 +172,35 @@ describe("buildResolver", function() {
             target: "안녕"
         }));
         var db = makeDb({});
-        var resolver = buildResolver(db, ts);
+        var resolver = buildResolver(db, ts, "myapp");
 
-        var params = resolver.makeLookupParams(makeTestResource("a", "A"), "ko-KR");
-        expect(params.commonPrjName).toBeUndefined();
+        expect(resolver.policy).toEqual([]);
     });
 
-    test("common project present — lookup params carry commonPrjName and commonPrjType", function() {
+    test("common project present — policy includes common entry with detected datatype", function() {
         var ts = makeCommonTs();
         var db = makeDb({});
-        var resolver = buildResolver(db, ts);
+        var resolver = buildResolver(db, ts, "myapp");
 
-        var params = resolver.makeLookupParams(makeTestResource("a", "A"), "ko-KR");
-        expect(params.commonPrjName).toBe("common");
-        expect(params.commonPrjType).toBe("javascript");
+        expect(resolver.policy).toEqual([
+            { project: "common", datatype: "javascript" }
+        ]);
     });
 
-    test("common project present but getBy returns empty — no common data in lookup params", function() {
+    test("common project present but getBy returns empty — empty policy", function() {
         var ts = new TranslationSet();
         ts.getProjects = function() { return ["common"]; };
         ts.getBy = function() { return []; };
         var db = makeDb({});
-        var resolver = buildResolver(db, ts);
+        var resolver = buildResolver(db, ts, "myapp");
 
-        var params = resolver.makeLookupParams(makeTestResource("a", "A"), "ko-KR");
-        expect(params.commonPrjName).toBeUndefined();
-        expect(params.commonPrjType).toBeUndefined();
+        expect(resolver.policy).toEqual([]);
     });
 
     test("makeLookupParams builds correct params object", function() {
         var ts = makeCommonTs();
         var db = makeDb({});
-        var resolver = buildResolver(db, ts);
+        var resolver = buildResolver(db, ts, "myapp");
 
         var resource = makeTestResource("hello", "Hello");
         var params = resolver.makeLookupParams(resource, "ko-KR");
@@ -212,22 +208,24 @@ describe("buildResolver", function() {
         expect(params.db).toBe(db);
         expect(params.resource).toBe(resource);
         expect(params.locale).toBe("ko-KR");
-        expect(params.policy).toEqual(buildPolicy());
-        expect(params.commonPrjName).toBe("common");
-        expect(params.commonPrjType).toBe("javascript");
+        expect(params.policy).toEqual([
+            { project: "common", datatype: "javascript" }
+        ]);
     });
 
     test("common data is captured at build time and reused across calls", function() {
         var ts = makeCommonTs();
         var db = makeDb({});
-        var resolver = buildResolver(db, ts);
+        var resolver = buildResolver(db, ts, "myapp");
 
         var first = resolver.makeLookupParams(makeTestResource("a", "A"), "ko-KR");
         var second = resolver.makeLookupParams(makeTestResource("b", "B"), "ja-JP");
 
-        expect(first.commonPrjName).toBe("common");
-        expect(second.commonPrjName).toBe("common");
-        expect(second.commonPrjType).toBe("javascript");
+        // Both share the same policy (same reference)
+        expect(first.policy).toBe(second.policy);
+        expect(first.policy).toEqual([
+            { project: "common", datatype: "javascript" }
+        ]);
     });
 });
 
@@ -350,10 +348,9 @@ describe("resolveTranslation", function() {
     test("direct miss + policy hit + differs from base → addResource", function(done) {
         var res = makeTestResource("hello", "Hello");
         var commonTranslated = makeTranslated("안녕", "Hello", "hello");
-        var policy = buildPolicy();
-        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "javascript", undefined);
+        var commonKey = ResourceString.cleanHashKey("common", "ko-KR", "hello", "javascript", undefined);
         var db = makeDb({ [commonKey]: commonTranslated });
-        var resolver = buildResolver(db, makeCommonTs());
+        var resolver = buildResolver(db, makeCommonTs(), "myapp");
         var resFileType = makeCollector();
         var newres = makeNewres();
 
@@ -376,9 +373,9 @@ describe("resolveTranslation", function() {
     test("direct miss + policy hit + same as base → addNewResource (skip)", function(done) {
         var res = makeTestResource("hello", "Hello");
         var commonTranslated = makeTranslated("Hello", "Hello", "hello");
-        var commonKey = ResourceString.hashKey("common", "ko-KR", "hello", "javascript", undefined);
+        var commonKey = ResourceString.cleanHashKey("common", "ko-KR", "hello", "javascript", undefined);
         var db = makeDb({ [commonKey]: commonTranslated });
-        var resolver = buildResolver(db, makeCommonTs());
+        var resolver = buildResolver(db, makeCommonTs(), "myapp");
         var resFileType = makeCollector();
         var newres = makeNewres();
 
@@ -427,10 +424,10 @@ describe("resolveTranslation", function() {
 
     test("direct miss + policy miss + customInherit direct miss + inherit policy hit → addResource", function(done) {
         var res = makeTestResource("hello", "Hello");
-        var inheritCommonKey = ResourceString.hashKey("common", "es", "hello", "javascript", undefined);
+        var inheritCommonKey = ResourceString.cleanHashKey("common", "es", "hello", "javascript", undefined);
         var inheritTranslated = makeTranslated("Hola", "Hello", "hello");
         var db = makeDb({ [inheritCommonKey]: inheritTranslated });
-        var resolver = buildResolver(db, makeCommonTs());
+        var resolver = buildResolver(db, makeCommonTs(), "myapp");
         var resFileType = makeCollector();
         var newres = makeNewres();
 

--- a/packages/ilib-loctool-webos-common/translationResolver.js
+++ b/packages/ilib-loctool-webos-common/translationResolver.js
@@ -52,18 +52,20 @@ function detectCommonData(translations) {
  * createLookupParams separately. Plugins call this once in write() and pass
  * the returned object to resolveTranslation().
  *
- * The common-project info is captured into the resolver at build time; this
- * function has no side effects on its arguments.
+ * All concrete values (project name, common project data) are resolved at
+ * build time and baked into the policy array. lookupByPolicy receives only
+ * { db, resource, locale, policy } — the policy entries are self-describing.
  *
- * @param {Object} db           - project.db handle
- * @param {Object} translations - the translations set passed to write()
- * @param {Object} [options]    - options passed to buildPolicy() for plugin-specific
- *   policy configuration (e.g. additional fallback steps)
+ * @param {Object} db             - project.db handle
+ * @param {Object} translations   - the translations set passed to write()
+ * @param {string} projectName    - current project name (e.g. project.getProjectId())
+ * @param {Object} [options]      - options passed to buildPolicy() for plugin-specific
+ *   policy configuration (e.g. { includeUniversal: true })
  * @returns {Object} resolver context with { db, policy, makeLookupParams }
  */
-function buildResolver(db, translations, options) {
+function buildResolver(db, translations, projectName, options) {
     var common = detectCommonData(translations);
-    var policy = buildPolicy(options);
+    var policy = buildPolicy(projectName, common, options);
 
     // Create lookup params factory
     var makeLookupParams = function(resource, locale) {
@@ -71,9 +73,7 @@ function buildResolver(db, translations, options) {
             db: db,
             resource: resource,
             locale: locale,
-            policy: policy,
-            commonPrjName: common.commonPrjName,
-            commonPrjType: common.commonPrjType
+            policy: policy
         };
     };
 

--- a/packages/ilib-loctool-webos-cpp/CppFileType.js
+++ b/packages/ilib-loctool-webos-cpp/CppFileType.js
@@ -124,7 +124,7 @@ CppFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations, { includeUniversal: true });
+    var resolver = buildResolver(db, translations, this.project.getProjectId(), { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-cpp/CppFileType.js
+++ b/packages/ilib-loctool-webos-cpp/CppFileType.js
@@ -124,7 +124,7 @@ CppFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations);
+    var resolver = buildResolver(db, translations, { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         }
     });
     test("cppsample_test_ko_KR", function() {
-        expect.assertions(7);
+        expect.assertions(9);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -106,6 +106,8 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(jsonData["Cancel"]).toBe("취소");
         expect(jsonData["Good      Morning"]).toBe("좋은 아침");
         expect(jsonData["* This feature is applied once and only once when the TV is turned off."]).toBe("* 이 기능은 기기 전원이 꺼질 때 한번만 실행됩니다."); //metadata
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
     });
     test("cppsample_test_es_CO", function() {
         expect.assertions(6);
@@ -163,7 +165,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
-        expect(Object.keys(jsonData).length).toBe(11);
+        expect(Object.keys(jsonData).length).toBe(13);
         expect(jsonData["Cancel"]).toBe("[Çàñçëľ210]");
         expect(jsonData["No"]).toBe("[Ňõ0]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppApp.test.js
@@ -95,7 +95,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         }
     });
     test("cppsample_test_ko_KR", function() {
-        expect.assertions(9);
+        expect.assertions(10);
         filePath = path.join(resourcePath, 'ko', fileName);
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -108,6 +108,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(jsonData["* This feature is applied once and only once when the TV is turned off."]).toBe("* 이 기능은 기기 전원이 꺼질 때 한번만 실행됩니다."); //metadata
         expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
         expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
+        expect(jsonData["See   you   later"]).toBe("또 만나(common)"); // common cleanHashKey (multispaces in source)
     });
     test("cppsample_test_es_CO", function() {
         expect.assertions(6);
@@ -165,7 +166,7 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
-        expect(Object.keys(jsonData).length).toBe(13);
+        expect(Object.keys(jsonData).length).toBe(14);
         expect(jsonData["Cancel"]).toBe("[Çàñçëľ210]");
         expect(jsonData["No"]).toBe("[Ňõ0]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/CppAppGenerate.test.js
@@ -76,20 +76,23 @@ describe("[integration] test the localization result of webos-cpp app", () => {
         }
     });
     test("cppsample_test_ko_KR_generate_mode", function() {
-        expect.assertions(9);
+        expect.assertions(12);
         filePath = path.join(resourcePath, 'ko', fileName);
 
         expect(process).toBeTruthy();
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
         jsonData = pluginUtils.loadData(filePath);
 
-        expect(Object.keys(jsonData).length).toBe(7);
+        expect(Object.keys(jsonData).length).toBe(9);
         expect(jsonData["No"]).toBe("아니오");
         expect(jsonData["Yes"]).toBe("예");
         expect(jsonData["Update"]).toBe("업데이트");
         expect(jsonData["Cancel"]).toBe("취소");
         expect(jsonData["Time Settings"]).toBe("시간 설정");
+        expect(jsonData["Good Morning"]).toBe("좋은 아침");
         expect(jsonData["* This feature is applied once and only once when the TV is turned off."]).toBe("* 이 기능은 프로젝터가 꺼질 때 한번만 실행됩니다.");
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal
     });
     test("cppsample_test_es_CO_generate_mode", function() {
        expect.assertions(3);

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(common)</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/common/ko-KR.xliff
@@ -8,6 +8,12 @@
           <target>재시도(common)</target>
         </segment>
       </unit>
+      <unit id="2">
+        <segment>
+          <source>See you later</source>
+          <target>또 만나(common)</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
@@ -9,3 +9,5 @@ std::string test8_label = ResBundleAdaptor::instance().getLocString("* This feat
 std::string test9_label = ResBundleAdaptor::instance().getLocString("TV Information");
 std::string test10_label = ResBundleAdaptor::instance().getLocString("TV Name");
 std::string test11_label = ResBundleAdaptor::instance().getLocString("Good      Morning"); // multispaces
+std::string test12_label = ResBundleAdaptor::instance().getLocString("EXIT APP");
+std::string test13_label = ResBundleAdaptor::instance().getLocString("RETRY");

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/src/test.cpp
@@ -11,3 +11,4 @@ std::string test10_label = ResBundleAdaptor::instance().getLocString("TV Name");
 std::string test11_label = ResBundleAdaptor::instance().getLocString("Good      Morning"); // multispaces
 std::string test12_label = ResBundleAdaptor::instance().getLocString("EXIT APP");
 std::string test13_label = ResBundleAdaptor::instance().getLocString("RETRY");
+std::string test14_label = ResBundleAdaptor::instance().getLocString("See   you   later"); // multispaces - common cleanHashKey

--- a/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-cpp/test/integrationTest/xliffs/ko-KR.xliff
@@ -61,5 +61,19 @@
         </segment>
       </unit>
     </group>
+    <group id="sample-webos-cpp_g2" name="universal">
+      <unit id="101">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 종료</target>
+        </segment>
+      </unit>
+      <unit id="102">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(universal)</target>
+        </segment>
+      </unit>
+    </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-dart/DartFileType.js
+++ b/packages/ilib-loctool-webos-dart/DartFileType.js
@@ -178,7 +178,7 @@ DartFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations);
+    var resolver = buildResolver(db, translations, { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-dart/DartFileType.js
+++ b/packages/ilib-loctool-webos-dart/DartFileType.js
@@ -178,7 +178,7 @@ DartFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations, { includeUniversal: true });
+    var resolver = buildResolver(db, translations, this.project.getProjectId(), { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -101,7 +101,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         }
     });
     test("dartsample_test_ko_KR", function() {
-        expect.assertions(6);
+        expect.assertions(8);
         filePath = path.join(resourcePath, 'ko.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -111,6 +111,8 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["Search"]).toBe("통합 검색");
         expect(jsonData["Internal Speaker"]).toBe("모니터 스피커"); // metadata
         expect(jsonData["Good      Morning"]).toBe("좋은 아침"); // keep multispaces
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
     });
     test("dartsample_test_es_CO", function() {
         expect.assertions(6);
@@ -171,7 +173,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
-        expect(Object.keys(jsonData).length).toBe(9);
+        expect(Object.keys(jsonData).length).toBe(11);
         expect(jsonData["App List"]).toBe("[Ãþþ Ľíšţ3210]");
         expect(jsonData["Back button"]).toBe("[ßàçķ büţţõñ543210]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartApp.test.js
@@ -101,7 +101,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         }
     });
     test("dartsample_test_ko_KR", function() {
-        expect.assertions(8);
+        expect.assertions(9);
         filePath = path.join(resourcePath, 'ko.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -113,6 +113,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(jsonData["Good      Morning"]).toBe("좋은 아침"); // keep multispaces
         expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal only
         expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal > common
+        expect(jsonData["See   you   later"]).toBe("또 만나(common)"); // common cleanHashKey (multispaces in source)
     });
     test("dartsample_test_es_CO", function() {
         expect.assertions(6);
@@ -173,7 +174,7 @@ describe('[integration] test the localization result of webos-dart app', () => {
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
         jsonData = pluginUtils.loadData(filePath);
-        expect(Object.keys(jsonData).length).toBe(11);
+        expect(Object.keys(jsonData).length).toBe(12);
         expect(jsonData["App List"]).toBe("[Ãþþ Ľíšţ3210]");
         expect(jsonData["Back button"]).toBe("[ßàçķ büţţõñ543210]");
         expect(jsonData["Programme"]).toBe("[Pŕõğŕàmmë43210]");

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/DartAppGenerate.test.js
@@ -79,7 +79,7 @@ describe('[integration] test the localization result (generate mode) of webos-da
         }
     });
     test("dartsample_generate_test_ko_KR", function() {
-        expect.assertions(7);
+        expect.assertions(9);
         filePath = path.join(resourcePath, 'ko.json');
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
 
@@ -90,6 +90,8 @@ describe('[integration] test the localization result (generate mode) of webos-da
         expect(jsonData["Live TV"]).toBe("현재 방송");
         expect(jsonData["Search"]).toBe("통합 검색");
         expect(jsonData["Internal Speaker"]).toBe("내부 스피커");
+        expect(jsonData["EXIT APP"]).toBe("앱 종료"); // universal
+        expect(jsonData["RETRY"]).toBe("재시도(universal)"); // universal
     });
     test("dartsample_generate_test_en_AU", function() {
         expect.assertions(3);

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/common/ko-KR.xliff
@@ -8,6 +8,12 @@
           <target>재시도(common)</target>
         </segment>
       </unit>
+      <unit id="2">
+        <segment>
+          <source>See you later</source>
+          <target>또 만나(common)</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/common/ko-KR.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(common)</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
@@ -9,3 +9,4 @@ translate('OK');
 translate('Good      Morning'); // multispaces
 translate('EXIT APP');
 translate('RETRY');
+translate('See   you   later'); // multispaces - common cleanHashKey

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/src/test.dart
@@ -7,3 +7,5 @@ translate('Internal Speaker', );
 translate('TV Name');
 translate('OK');
 translate('Good      Morning'); // multispaces
+translate('EXIT APP');
+translate('RETRY');

--- a/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-dart/test/integrationTest/xliffs/ko-KR.xliff
@@ -52,5 +52,19 @@
         </segment>
       </unit>
     </group>
+    <group id="sample-webos-dart_g2" name="universal">
+      <unit id="101">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 종료</target>
+        </segment>
+      </unit>
+      <unit id="102">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(universal)</target>
+        </segment>
+      </unit>
+    </group>
   </file>
 </xliff>

--- a/packages/ilib-loctool-webos-javascript/JavaScriptFileType.js
+++ b/packages/ilib-loctool-webos-javascript/JavaScriptFileType.js
@@ -128,7 +128,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations);
+    var resolver = buildResolver(db, translations, { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-javascript/JavaScriptFileType.js
+++ b/packages/ilib-loctool-webos-javascript/JavaScriptFileType.js
@@ -128,7 +128,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     // Build resolver: detects common project data and prepares policy-based lookup.
-    var resolver = buildResolver(db, translations, { includeUniversal: true });
+    var resolver = buildResolver(db, translations, this.project.getProjectId(), { includeUniversal: true });
 
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -95,19 +95,22 @@ describe('[integration] test the localization result of webos-js app', () => {
         }
     });
     test("jssample_test_ko_KR", function() {
-        expect.assertions(8);
+        expect.assertions(11);
         let rb = new ResBundle({
             locale:"ko-KR",
             basePath : defaultRSPath
         });
         expect(rb).toBeTruthy();
-        expect(rb.getString("Hello").toString()).toBe("안녕");
-        expect(rb.getString("Thank you").toString()).toBe("고마워");
-        expect(rb.getString("Bye").toString()).toBe("잘가");
-        expect(rb.getString("Time Settings").toString()).toBe("시간 설정");
+        expect(rb.getString("Hello").toString()).toBe("안녕"); // self type (javascript)
+        expect(rb.getString("Thank you").toString()).toBe("고마워"); // self type (javascript)
+        expect(rb.getString("Bye").toString()).toBe("잘가"); // self type (javascript)
+        expect(rb.getString("Time Settings").toString()).toBe("시간 설정"); // common
         expect(rb.getString("%deviceType% Speaker").toString()).toBe("모니터 스피커"); //metadata-common
         expect(rb.getString("Internal Speaker + Wired Headphones").toString()).toBe("모니터 스피커 + 유선 헤드폰"); //metadata
         expect(rb.getString("Good Morning").toString()).toBe("좋은 아침"); // clean multispaces
+        expect(rb.getString("EXIT APP").toString()).toBe("앱 종료"); // universal only
+        expect(rb.getString("Sound Out").toString()).toBe("사운드 출력(universal)"); // universal only
+        expect(rb.getString("RETRY").toString()).toBe("재시도(universal)"); // universal > common
     });
     test("jssample_test_ko_CN", function() {
         expect.assertions(2);

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/JsApp.test.js
@@ -95,7 +95,7 @@ describe('[integration] test the localization result of webos-js app', () => {
         }
     });
     test("jssample_test_ko_KR", function() {
-        expect.assertions(11);
+        expect.assertions(12);
         let rb = new ResBundle({
             locale:"ko-KR",
             basePath : defaultRSPath
@@ -111,6 +111,7 @@ describe('[integration] test the localization result of webos-js app', () => {
         expect(rb.getString("EXIT APP").toString()).toBe("앱 종료"); // universal only
         expect(rb.getString("Sound Out").toString()).toBe("사운드 출력(universal)"); // universal only
         expect(rb.getString("RETRY").toString()).toBe("재시도(universal)"); // universal > common
+        expect(rb.getString("See you later").toString()).toBe("또 만나(common)"); // common cleanHashKey (multispaces in source)
     });
     test("jssample_test_ko_CN", function() {
         expect.assertions(2);

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/common/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/common/ko-KR.xliff
@@ -14,6 +14,12 @@
           <target>재시도(common)</target>
         </segment>
       </unit>
+      <unit id="common_5">
+        <segment>
+          <source>See you later</source>
+          <target>또 만나(common)</target>
+        </segment>
+      </unit>
       <unit id="common_34">
         <mda:metadata>
           <mda:metaGroup category="device-type">

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
@@ -6,6 +6,8 @@ msg5.reason = $L('Sound Out');
 msg6.reason = $L('Programme');
 msg7.reason = $L('Internal Speaker + Wired Headphones');
 msg8.reason = $L('TV Name');
+msg9.reason = $L('EXIT APP');
+msg10.reason = $L('RETRY');
 
 $L('%deviceType% Speaker'),
 $L('Good      Morning'); // multispaces -> cleaned up in the resource bundle

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/src/sample.js
@@ -11,3 +11,4 @@ msg10.reason = $L('RETRY');
 
 $L('%deviceType% Speaker'),
 $L('Good      Morning'); // multispaces -> cleaned up in the resource bundle
+$L('See   you   later'); // multispaces - common cleanHashKey lookup

--- a/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
+++ b/packages/ilib-loctool-webos-javascript/test/integrationTest/xliffs/ko-KR.xliff
@@ -46,5 +46,25 @@
         </segment>
       </unit>
     </group>
+    <group id="sample-webos-js_g2" name="universal">
+      <unit id="101">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 종료</target>
+        </segment>
+      </unit>
+      <unit id="102">
+        <segment>
+          <source>Sound Out</source>
+          <target>사운드 출력(universal)</target>
+        </segment>
+      </unit>
+      <unit id="103">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도(universal)</target>
+        </segment>
+      </unit>
+    </group>
   </file>
 </xliff>

--- a/packages/samples-loctool/webos-js-with-universal/CHANGELOG.md
+++ b/packages/samples-loctool/webos-js-with-universal/CHANGELOG.md
@@ -1,0 +1,1 @@
+# sample-webos-js-with-universal

--- a/packages/samples-loctool/webos-js-with-universal/CHANGELOG.md
+++ b/packages/samples-loctool/webos-js-with-universal/CHANGELOG.md
@@ -1,1 +1,0 @@
-# sample-webos-js-with-universal

--- a/packages/samples-loctool/webos-js-with-universal/appinfo.json
+++ b/packages/samples-loctool/webos-js-with-universal/appinfo.json
@@ -1,0 +1,19 @@
+{
+    "id": "sample-webos-js",
+    "version": "4.0.1",
+    "type": "web",
+    "main": "index.html",
+    "title": "Live TV",
+    "icon": "icon.png",
+    "uiRevision": 2,
+    "transparent": true,
+    "visible": false,
+    "lockable": false,
+    "trustLevel": "trusted",
+    "accessibility": {
+        "supportsAudioGuidance": true
+    },
+    "voiceControl": "manual",
+    "v8SnapshotFile": "snapshot_blob.bin",
+    "vendor": "test"
+}

--- a/packages/samples-loctool/webos-js-with-universal/common/en-GB.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/en-GB.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Game Optimizer</source>
+          <target>Game Optimiser</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>HDMI Deep Color</source>
+          <target>HDMI Deep Colour</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/common/es-CO.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>Aceptar</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/common/es-ES.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="1">
+        <segment>
+          <source>OK</source>
+          <target>OK</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/common/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/fr-CA.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/common/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/fr-FR.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
+  <file id="common_f1" original="common">
+    <group id="common_g1" name="javascript">
+      <unit id="common_1">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+      <unit id="common_2">
+        <segment>
+          <source>Exit</source>
+          <target>Quitter</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/ko-KR.xliff
@@ -5,13 +5,13 @@
       <unit id="common_1">
         <segment>
           <source>Time Settings</source>
-          <target>시간 설정</target>
+          <target>[common] 시간 설정</target>
         </segment>
       </unit>
       <unit id="common_2">
         <segment>
-          <source>RETRY</source>
-          <target>재시도(common)</target>
+          <source>Please enter password.</source>
+          <target>[common] 비밀번호를 입력해 주세요.</target>
         </segment>
       </unit>
       <unit id="common_34">

--- a/packages/samples-loctool/webos-js-with-universal/common/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/common/ko-KR.xliff
@@ -30,6 +30,12 @@
           <target>TV 스피커</target>
         </segment>
       </unit>
+      <unit id="common_4">
+        <segment>
+          <source>Lookup Priority</source>
+          <target>우선순위(common)</target>
+        </segment>
+      </unit>
     </group>
   </file>
 </xliff>

--- a/packages/samples-loctool/webos-js-with-universal/package.json
+++ b/packages/samples-loctool/webos-js-with-universal/package.json
@@ -1,0 +1,30 @@
+{
+    "private": true,
+    "name": "sample-webos-js-with-universal",
+    "description": "Sample localization project using the universal datatype",
+    "repository": "git@github.com:iLib-js/ilib-mono-webos.git",
+    "license": "Apache-2.0",
+    "version": "1.0.0",
+    "scripts": {
+        "loc": "loctool -2 --xliffStyle webOS --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB --pseudo",
+        "debug": "node --inspect-brk node_modules/loctool/loctool.js -2 --xliffStyle webOS --localeMap es-CO:es --localeInherit en-AU:en-GB --pseudo",
+        "clean": "rm -rf *.xliff resources resources2",
+        "loc-generate": "loctool generate -2 --translations xliffs --xliffStyle webOS --projectType custom --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json  --projectId sample-webos-js-with-universal -l as-IN,de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP:en-GB",
+        "loc-generate-debug": "node --inspect-brk node_modules/loctool/loctool.js generate -2 --translations xliffs --xliffStyle webOS --projectType webos-js --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-json --projectId sample-webos-js-with-universal -l de-DE,en-AU,en-US,en-GB,en-JP,es-ES,es-CO,fr-CA,fr-FR,ja-JP,ko-KR,ko-US,ko-TW --localeMap es-CO:es,fr-CA:fr --localeInherit en-AU:en-GB,en-JP,en-GB",
+        "coverage": "pnpm test --coverage",
+        "test": "pnpm test:jest",
+        "test:jest": "LANG=en_US.UTF8 node node_modules/jest/bin/jest.js",
+        "test-debug": "node --inspect-brk node_modules/jest/bin/jest.js -i"
+    },
+    "dependencies": {
+        "ilib-loctool-webos-javascript": "workspace:*",
+        "ilib-loctool-webos-json": "workspace:*",
+        "ilib-loctool-webos-json-resource": "workspace:*",
+        "ilib-loctool-webos-common": "workspace:*",
+        "loctool": "^2.33.1"
+    },
+    "devDependencies": {
+        "ilib": "^14.21.3",
+        "jest": "^30.3.0"
+    }
+}

--- a/packages/samples-loctool/webos-js-with-universal/project.json
+++ b/packages/samples-loctool/webos-js-with-universal/project.json
@@ -1,0 +1,67 @@
+{
+    "name": "sample-webos-js-with-universal",
+    "id": "sample-webos-js-with-universal",
+    "projectType": "webos-js",
+    "sourceLocale": "en-KR",
+    "pseudoLocale":  {
+        "zxx-XX": "debug",
+        "zxx-Hebr-XX": "debug-rtl",
+        "zxx-Cyrl-XX": "debug-cyrillic",
+        "zxx-Hans-XX": "debug-han-simplified",
+        "as-XX" : "debug-font"
+    },
+    "resourceDirs": {
+        "json":"resources"
+    },
+    "resourceFileTypes": {
+        "json":"ilib-loctool-webos-json-resource"
+    },
+    "plugins": [
+        "ilib-loctool-webos-javascript",
+        "ilib-loctool-webos-json"
+    ],
+    "excludes": [
+        ".*",
+        "test",
+        "xliffs",
+        "common"
+    ],
+    "settings": {
+        "translationsDir": ["./xliffs", "./common"],
+        "locales":[
+            "as-IN",
+            "de-DE",
+            "es-CO",
+            "es-ES",
+            "en-US",
+            "fr-CA",
+            "fr-FR",
+            "ja-JP",
+            "ko-KR",
+            "ko-US",
+            "ko-TW",
+            "en-AU",
+            "en-GB"
+        ],
+        "localeMap": {
+            "fr-CA": "fr"
+        },
+        "localeInherit": {
+            "en-CN": "en-GB",
+            "en-AU": "en-GB"
+        },
+        "jsonMap": {
+            "mappings": {
+                "**/appinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                },
+                "**/qcardinfo.json": {
+                    "template": "[dir]/[resourceDir]/[localeDir]/[filename]"
+                }
+            }
+        },
+        "javascript": {
+            "disablePseudo": true
+        }
+    }
+}

--- a/packages/samples-loctool/webos-js-with-universal/src/msg.js
+++ b/packages/samples-loctool/webos-js-with-universal/src/msg.js
@@ -30,6 +30,10 @@ export function findMsgByCode (code) {
             break;
         case 10:
             msg.reason = $L('%deviceType% Speaker');
+            break;
+        case 11:
+            msg.reason = $L('Lookup Priority');
+            break;
         default:
             msg.reason = $L('Bye');
             break;

--- a/packages/samples-loctool/webos-js-with-universal/src/msg.js
+++ b/packages/samples-loctool/webos-js-with-universal/src/msg.js
@@ -1,0 +1,103 @@
+import $L from '@enact/i18n/$L';
+export function findMsgByCode (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Hello'); // i18n : i18n comments
+            break;
+        case 2:
+            msg.reason = $L('Thank you');
+            break;
+        case 3:
+            msg.reason = $L('Congratulation');
+            break;
+        case 4:
+            msg.reason = $L('Antenna NEXTGEN TV');
+            break;
+        case 5:
+            msg.reason = $L('Game Optimizer');
+            break;
+        case 6:
+            msg.reason = $L('HDMI Deep Color');
+            break;
+        case 7:
+            msg.reason = $L('Exit');
+            break;
+        case 8:
+            msg.reason = $L('OK');
+            break;
+        case 9:
+            msg.reason = $L('Restart');
+            break;
+        case 10:
+            msg.reason = $L('%deviceType% Speaker');
+        default:
+            msg.reason = $L('Bye');
+            break;
+    }
+    return msg;
+}
+export function findMsgByCode2 (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Agree');
+            break;
+        case 2:
+            msg.reason = $L('Ivory Coast');
+            break;
+        default:
+            msg.reason = $L('Programme');
+            break;
+    }
+    return msg;
+}
+export function findMsgByCode3 (code) {
+    switch (code) {
+        case 1:
+            msg.reason = $L('Live TV'); // xliff_target: nbsp
+            break;
+        case 2:
+            msg.reason = $L('Space NBSP'); // xliff_source: nbsp
+            break;
+        case 3:
+            msg.reason = $L('To read the Terms and Conditions, go to Settings > Support >            Privacy & Terms.'); // multi-spaces
+            break;
+        case 4:
+            msg.reason = $L('TV Name : '); // xliff_target trim
+            break;
+        case 5:
+            msg.reason = $L('Sound Out');
+            break;
+        case 6:
+            msg.reason = $L('TV Program Locks');
+            break;
+        case 7:
+            msg.reason = $L('Service Area Zip Code');
+            break;
+        case 8:
+            msg.reason = $L('Time Settings');
+            break;
+        case 9:
+            msg.reason = $L('Please enter password.');
+            break;
+        case 10:
+            msg.reason = $L('Others');
+        case 11:
+            $L("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.")
+            break;
+        case 12:
+            $L({key: 'volumeModeHigh', value: 'High' });
+            break;
+        case 13:
+            $L("TV On Screen");
+            break;
+        case 14:
+            toIString($L("IPv6 e.g.: \n{ipAddress}")).format({ipAddress: "fe80::1ff:fe23:4567:890a:5900"})
+        case 15:
+            toIString($L("IPv4 e.g.: \t{ip4Address}")).format({ipAddress: "123.123.456.456"})
+        default:
+            msg.reason = $L('MAC Address'); // xliff_target trim
+            break;
+    }
+    return msg;
+}
+

--- a/packages/samples-loctool/webos-js-with-universal/src/msg2.js
+++ b/packages/samples-loctool/webos-js-with-universal/src/msg2.js
@@ -1,0 +1,24 @@
+webappResBundle = new ResBundle({
+    basePath: "../resources"
+});
+
+function setButtonsOnPage(layoutCase) {
+    switch (layoutCase) {
+    case 0:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        break;
+    case 1:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("RETRY"), "Retry_Button", dir_tail, onRetryApp);
+        break;
+    case 2:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("SETTINGS"), "Setting_Button", dir_tail, onLaunchGeneralSetting);
+        createButtonOnPage(webappResBundle.getString("RETRY"), "Retry_Button", dir_tail, onRetryApp);
+        break;
+    default:
+        createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
+        createButtonOnPage(webappResBundle.getString("CLOSE"), "ExitApp_Button", dir_head, onExitApp);
+        break;
+    }
+}

--- a/packages/samples-loctool/webos-js-with-universal/test/JsApp.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsApp.test.js
@@ -41,7 +41,7 @@ describe('test the localization result of webos-js app', () => {
         });
     }, 50000);
     test("jssample_test_ko_KR", function() {
-        expect.assertions(13);
+        expect.assertions(14);
         let rb = new ResBundle({
             locale:"ko-KR",
             basePath : defaultRSPath
@@ -62,6 +62,9 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("Please enter password.").toString()).toBe("[common] 비밀번호를 입력해 주세요.");
         // common-metadata
         expect(rb.getString("%deviceType% Speaker").toString()).toBe("모니터 스피커");
+
+        // lookup priority: javascript > universal > common
+        expect(rb.getString("Lookup Priority").toString()).toBe("우선순위(javascript)");
     });
     test("jssample_test_ko_US", function() {
         expect.assertions(2);

--- a/packages/samples-loctool/webos-js-with-universal/test/JsApp.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsApp.test.js
@@ -1,0 +1,278 @@
+/*
+ * JsApp.test.js - test the localization result of webos-js app.
+ *
+ * Copyright (c) 2025-2026 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require("fs");
+const { exec } = require('child_process');
+const path = require('path');
+const ResBundle = require("ilib/lib/ResBundle");
+const defaultRSPath = path.join(process.cwd(), "resources");
+const { utils: pluginUtils } = require("ilib-loctool-webos-common");
+
+describe('test the localization result of webos-js app', () => {
+    const generalOptions = '-2 --xliffStyle webOS --pseudo --localizeOnly';
+    const localeInherit = '--localeInherit en-AU:en-GB';
+    const localeMap = '--localeMap es-CO:es,fr-CA:fr';
+    const deviceOption = '--metadata device-type=Monitor';
+    let fullPath = '';
+
+    beforeAll(async() => {
+        await new Promise((resolve, reject) => {
+            exec(`npm run clean; loctool ${generalOptions} ${localeMap} ${localeInherit} ${deviceOption}`, (error, stdout, stderr) => {
+                if (error) {
+                    return reject(error);
+                }
+                resolve(stdout);
+            });
+        });
+    }, 50000);
+    test("jssample_test_ko_KR", function() {
+        expect.assertions(13);
+        let rb = new ResBundle({
+            locale:"ko-KR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("TV Name : ").toString()).toBe("TV Name :");
+        expect(rb.getString("Time Settings").toString()).toBe("[App] 시간 설정");
+        expect(rb.getString("High", "volumeModeHigh").toString()).toBe("높음");
+        expect(rb.getString("TV On Screen").toString()).toBe("TV 켜짐 화면");
+        expect(rb.getString("IPv6 e.g.: {ipAddress}").toString()).toBe("IPv6 예시: {ipAddress}");
+        expect(rb.getString("IPv4 e.g.: {ip4Address}").toString()).toBe("IPv4 예시: {ip4Address}");
+        expect(rb.getString("Bye").toString()).toBe("잘가");
+        expect(rb.getString("Hello").toString()).toBe("안녕");
+        expect(rb.getString("Thank you").toString()).toBe("고마워");
+        expect(rb.getString("SETTINGS").toString()).toBe("설정");
+
+        // common data
+        expect(rb.getString("Please enter password.").toString()).toBe("[common] 비밀번호를 입력해 주세요.");
+        // common-metadata
+        expect(rb.getString("%deviceType% Speaker").toString()).toBe("모니터 스피커");
+    });
+    test("jssample_test_ko_US", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"ko-US",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Antenna NEXTGEN TV").toString()).toBe("안테나 NEXTGEN TV");
+    });
+    test("jssample_test_ko_TW", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"ko-TW",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("TV On Screen").toString()).toBe("기기 켜짐 화면");
+    });
+    test("jssample_test_en_AU", function() {
+        expect.assertions(10);
+
+        let rb = new ResBundle({
+            locale:"en-AU",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Service Area Zip Code").toString()).toBe("Service Area Postcode");
+        expect(rb.getString("TV Program Locks").toString()).toBe("TV Rating Locks");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+        expect(rb.getString("Ivory Coast").toString()).toBe("Côte d’Ivoire");
+
+        fullPath = path.join(defaultRSPath, "en/AU/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
+        expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
+
+        // common data's locale Inheritence
+        expect(rb.getString("Game Optimizer").toString()).toBe("Game Optimiser");
+        expect(rb.getString("HDMI Deep Color").toString()).toBe("HDMI Deep Colour");
+
+        // multi-spaces
+        expect(rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString()).toBe("Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.");
+    });
+    test("jssample_test_en_GB", function() {
+        expect.assertions(10);
+
+        let rb = new ResBundle({
+            locale:"en-GB",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Service Area Zip Code").toString()).toBe("Service Area Postcode");
+        expect(rb.getString("TV Program Locks").toString()).toBe("TV Rating Locks");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+        expect(rb.getString("Ivory Coast").toString()).toBe("Côte d’Ivoire");
+
+        fullPath = path.join(defaultRSPath, "en/GB/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
+        expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
+
+        // common data's locale Inheritence
+        expect(rb.getString("Game Optimizer").toString()).toBe("Game Optimiser");
+        expect(rb.getString("HDMI Deep Color").toString()).toBe("HDMI Deep Colour");
+
+        // multi-spaces
+        expect(rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString()).toBe("Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.");
+    });
+    test("jssample_test_fr_CA", function() {
+        expect.assertions(5);
+
+        let rb = new ResBundle({
+            locale:"fr-CA",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Agree").toString()).toBe("D’accord");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+        
+        expect(rb.getString("Exit").toString()).toBe("Quitter"); //common data
+        
+        fullPath = path.join(defaultRSPath, "fr/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Exit")).toBeTruthy();
+    });
+    test("jssample_test_fr_FR", function() {
+        expect.assertions(6);
+        let rb = new ResBundle({
+            locale:"fr-FR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Agree").toString()).toBe("J'accepte");
+        expect(rb.getString("Others").toString()).toBe("Autres");
+        
+        expect(rb.getString("Exit").toString()).toBe("Quitter"); //common data
+
+        fullPath = path.join(defaultRSPath, "fr/FR/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Others")).toBeFalsy();
+        expect(pluginUtils.isExistKey(fullPath, "Exit")).toBeFalsy();
+        
+    });
+    test("jssample_test_es_ES", function() {
+        expect.assertions(4);
+        let rb = new ResBundle({
+            locale:"es-ES",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Sound Out").toString()).toBe("Salida de sonido");
+
+        expect(rb.getString("OK").toString()).toBe("OK"); //common data
+        fullPath = path.join(defaultRSPath, "es/ES/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "OK")).toBeTruthy();
+    });
+    test("jssample_test_es_CO", function() {
+        expect.assertions(3);
+        let rb = new ResBundle({
+            locale:"es-CO",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Sound Out").toString()).toBe("Salida de Audio");
+        expect(rb.getString("OK").toString()).toBe("Aceptar"); // common data
+    });
+    test("jssample_test_ja_JP", function() {
+        expect.assertions(6);
+
+        let rb = new ResBundle({
+            locale:"ja-JP",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Live TV").toString()).toBe("Live TV");
+        expect(rb.getString("TV Name : ").toString()).toBe("機器名：");
+        expect(rb.getString("MAC Address").toString()).toBe("MAC Address ");
+        expect(rb.getString("Space NBSP").toString()).toBe("現実の時間とは異なり、");
+
+        // fyi. https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/34
+        expect(rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString()).toBe("利用規約を読むには、設定 > サポート > 利用規約 & 法的情報に移動します。");
+    });
+    test("jssample_test_de_DE", function() {
+        expect.assertions(6);
+        let rb = new ResBundle({
+            locale:"de-DE",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Bye").toString()).toBe("Auf wiedersehen");
+        expect(rb.getString("EXIT APP").toString()).toBe("APP BEENDEN");
+        expect(rb.getString("Hello").toString()).toBe("Hallo");
+        expect(rb.getString("RETRY").toString()).toBe("WIEDERHOLEN");
+        expect(rb.getString("SETTINGS").toString()).toBe("EINSTELLUNGEN");
+    });
+    test("jssample_test_as_IN", function() {
+        expect.assertions(3);
+        let rb = new ResBundle({
+            locale:"as-IN",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("RETRY").toString()).toBe("পুনৰ চেষ্টা");
+        expect(rb.getString("Restart").toString()).toBe("পুনৰাম্ভ কৰক");
+    });
+
+    test("jssample_test_appinfo_locale_files", function() {
+        expect.assertions(8);
+
+        const asAppinfo = path.join(defaultRSPath, "as/appinfo.json");
+        const jaAppinfo = path.join(defaultRSPath, "ja/appinfo.json");
+        const koAppinfo = path.join(defaultRSPath, "ko/appinfo.json");
+
+        expect(pluginUtils.isValidPath(asAppinfo)).toBeTruthy();
+        expect(pluginUtils.isValidPath(jaAppinfo)).toBeTruthy();
+        expect(pluginUtils.isValidPath(koAppinfo)).toBeTruthy();
+
+        expect(Object.keys(pluginUtils.loadData(asAppinfo)).sort()).toEqual(["title", "vendor"]);
+        expect(Object.keys(pluginUtils.loadData(jaAppinfo)).sort()).toEqual(["title"]);
+        expect(Object.keys(pluginUtils.loadData(koAppinfo)).sort()).toEqual(["title"]);
+        expect(pluginUtils.loadData(jaAppinfo)["title"]).toBe("Live TV");
+        expect(pluginUtils.loadData(koAppinfo)["title"]).toBe("현재 방송");
+    });
+
+    test("jssample_test_appinfo_zxx_file_list", function() {
+        expect.assertions(1);
+        const zxxPath = path.join(defaultRSPath, "zxx");
+        const pseudoAppInfoFiles = [];
+
+        const walk = (dirPath) => {
+            const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+            entries.forEach((entry) => {
+                const fullPath = path.join(dirPath, entry.name);
+                if (entry.isDirectory()) {
+                    walk(fullPath);
+                } else if (entry.isFile() && entry.name === "appinfo.json") {
+                    pseudoAppInfoFiles.push(path.relative(zxxPath, fullPath).split(path.sep).join("/"));
+                }
+            });
+        };
+
+        walk(zxxPath);
+        expect(pseudoAppInfoFiles.sort()).toEqual([
+            "Cyrl/XX/appinfo.json",
+            "Hans/XX/appinfo.json",
+            "Hebr/XX/appinfo.json",
+            "appinfo.json"
+        ]);
+    });
+
+    test("jssample_test_appinfo_zxx_single_file_keys", function() {
+        expect.assertions(2);
+        const filePath = path.join(defaultRSPath, "zxx", "appinfo.json");
+        expect(pluginUtils.isValidPath(filePath)).toBeTruthy();
+        expect(Object.keys(pluginUtils.loadData(filePath)).sort()).toEqual(["title", "vendor"]);
+    });
+});

--- a/packages/samples-loctool/webos-js-with-universal/test/JsAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsAppGenerate.test.js
@@ -1,0 +1,224 @@
+/*
+ * JsAppGenerate.test.js - test the localization result in generate mode of webos-js app.
+ *
+ * Copyright (c) 2025-2026 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require('path');
+const ResBundle = require("ilib/lib/ResBundle");
+const defaultRSPath = path.join(process.cwd(), "resources2");
+const { utils: pluginUtils } = require("ilib-loctool-webos-common");
+
+const ProjectFactory = require("loctool/lib/ProjectFactory.js");
+const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
+
+describe('test the localization result (generate mode) of webos-js app', () => {
+    beforeAll(async() => {
+        const outputPath = "./resources2";
+        if (fs.existsSync(outputPath)) {
+            fs.rmSync(outputPath, { recursive: true });
+        }
+        const projectSettings = {
+            rootDir: ".",
+            id: "sample-webos-js-with-universal",
+            projectType: "webos-js",
+            sourceLocale: "en-KR",
+            resourceDirs : { "json": "resources2" },
+            resourceFileTypes: { "json":"ilib-loctool-webos-json-resource" },
+            plugins: [ "ilib-loctool-webos-javascript" ]
+        };
+        const appSettings = {
+            translationsDir: "./xliffs",
+            xliffStyle: "webOS",
+            xliffVersion: 2,
+            locales:[
+                "as-IN",
+                "de-DE",
+                "en-AU",
+                "en-US",
+                "en-GB",
+                "en-JP",
+                "es-ES",
+                "es-CO",
+                "fr-CA",
+                "fr-FR",
+                "ja-JP",
+                "ko-KR",
+                "ko-US",
+                "ko-TW"
+            ],
+            localeMap: {
+                "es-CO": "es",
+                "fr-CA": "fr"
+            },
+            localeInherit: {
+                "en-AU": "en-GB",
+                "en-JP": "en-GB",
+            }
+        };
+        const project = ProjectFactory.newProject(projectSettings, appSettings);
+        GenerateModeProcess(project);
+
+    }, 50000);
+    test("jssample_generate_test_ko_KR", function() {
+        expect.assertions(8);
+        let rb = new ResBundle({
+            locale:"ko-KR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("TV Name : ").toString()).toBe("TV Name :");
+        expect(rb.getString("Time Settings").toString()).toBe("[App] 시간 설정");
+        expect(rb.getString("High", "volumeModeHigh").toString()).toBe("높음");
+        expect(rb.getString("TV On Screen").toString()).toBe("TV 켜짐 화면");
+        expect(rb.getString("Bye").toString()).toBe("잘가");
+        expect(rb.getString("SETTINGS").toString()).toBe("설정");
+
+        // common data
+        expect(rb.getString("Please enter password.").toString()).toBe("Please enter password.");
+    });
+    test("jssample_generate_test_ko_US", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"ko-US",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Antenna NEXTGEN TV").toString()).toBe("안테나 NEXTGEN TV");
+    });
+    test("jssample_test_ko_TW", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"ko-TW",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("TV On Screen").toString()).toBe("기기 켜짐 화면");
+    })
+    test("jssample_generate_test_en_AU", function() {
+        expect.assertions(7);
+
+        let rb = new ResBundle({
+            locale:"en-AU",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Service Area Zip Code").toString()).toBe("Service Area Postcode");
+        expect(rb.getString("TV Program Locks").toString()).toBe("TV Rating Locks");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+        expect(rb.getString("Ivory Coast").toString()).toBe("Côte d’Ivoire");
+
+        let fullPath = path.join(defaultRSPath, "en/AU/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
+        expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
+    });
+    test("jssample_generate_test_en_GB", function() {
+        expect.assertions(7);
+
+        let rb = new ResBundle({
+            locale:"en-GB",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Service Area Zip Code").toString()).toBe("Service Area Postcode");
+        expect(rb.getString("TV Program Locks").toString()).toBe("TV Rating Locks");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+        expect(rb.getString("Ivory Coast").toString()).toBe("Côte d’Ivoire");
+
+        let fullPath = path.join(defaultRSPath, "en/GB/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
+        expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
+    });
+    test("jssample_generate_test_fr_CA", function() {
+        expect.assertions(3);
+
+        let rb = new ResBundle({
+            locale:"fr-CA",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Agree").toString()).toBe("D’accord");
+        expect(rb.getString("Programme").toString()).toBe("Programme");
+    });
+    test("jssample_generate_test_fr_FR", function() {
+        expect.assertions(4);
+        let rb = new ResBundle({
+            locale:"fr-FR",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Agree").toString()).toBe("J'accepte");
+        expect(rb.getString("Others").toString()).toBe("Autres");
+
+        let fullPath = path.join(defaultRSPath, "en/FR/strings.json");
+        expect(pluginUtils.isExistKey(fullPath, "Others")).toBeFalsy();
+    });
+    test("jssample_generate_test_es_ES", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"es-ES",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Sound Out").toString()).toBe("Salida de sonido");
+    });
+    test("jssample_generate_test_es_CO", function() {
+        expect.assertions(2);
+        let rb = new ResBundle({
+            locale:"es-CO",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Sound Out").toString()).toBe("Salida de Audio");
+    });
+    test("jssample_generate_test_ja_JP", function() {
+        expect.assertions(5);
+        let rb = new ResBundle({
+            locale:"ja-JP",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Live TV").toString()).toBe("Live TV");
+        expect(rb.getString("TV Name : ").toString()).toBe("機器名：");
+        expect(rb.getString("MAC Address").toString()).toBe("MAC Address ");
+
+        expect(rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString()).toBe("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.");
+    });
+    test("jssample_generate_test_de_DE", function() {
+        expect.assertions(6);
+        let rb = new ResBundle({
+            locale:"de-DE",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("Bye").toString()).toBe("Auf wiedersehen");
+        expect(rb.getString("EXIT APP").toString()).toBe("APP BEENDEN");
+        expect(rb.getString("Hello").toString()).toBe("Hallo");
+        expect(rb.getString("RETRY").toString()).toBe("WIEDERHOLEN");
+        expect(rb.getString("SETTINGS").toString()).toBe("EINSTELLUNGEN");
+    });
+    test("jssample_generate_test_as_IN", function() {
+        expect.assertions(3);
+        let rb = new ResBundle({
+            locale:"as-IN",
+            basePath : defaultRSPath
+        });
+        expect(rb).toBeTruthy();
+        expect(rb.getString("RETRY").toString()).toBe("পুনৰ চেষ্টা");
+        expect(rb.getString("Restart").toString()).toBe("পুনৰাম্ভ কৰক");
+    });
+});

--- a/packages/samples-loctool/webos-js-with-universal/test/JsUniversalApp.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsUniversalApp.test.js
@@ -1,5 +1,5 @@
 /*
- * JsApp.test.js - test the localization result of webos-js app.
+ * JsUniversalApp.test.js - test the localization result of webos-js-with-universal app.
  *
  * Copyright (c) 2025-2026 JEDLSoft
  *
@@ -23,7 +23,7 @@ const ResBundle = require("ilib/lib/ResBundle");
 const defaultRSPath = path.join(process.cwd(), "resources");
 const { utils: pluginUtils } = require("ilib-loctool-webos-common");
 
-describe('test the localization result of webos-js app', () => {
+describe('test the localization result of webos-js-with-universal app', () => {
     const generalOptions = '-2 --xliffStyle webOS --pseudo --localizeOnly';
     const localeInherit = '--localeInherit en-AU:en-GB';
     const localeMap = '--localeMap es-CO:es,fr-CA:fr';
@@ -40,7 +40,7 @@ describe('test the localization result of webos-js app', () => {
             });
         });
     }, 50000);
-    test("jssample_test_ko_KR", function() {
+    test("jsuniv_test_ko_KR", function() {
         expect.assertions(14);
         let rb = new ResBundle({
             locale:"ko-KR",
@@ -66,7 +66,7 @@ describe('test the localization result of webos-js app', () => {
         // lookup priority: javascript > universal > common
         expect(rb.getString("Lookup Priority").toString()).toBe("우선순위(javascript)");
     });
-    test("jssample_test_ko_US", function() {
+    test("jsuniv_test_ko_US", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"ko-US",
@@ -75,7 +75,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("Antenna NEXTGEN TV").toString()).toBe("안테나 NEXTGEN TV");
     });
-    test("jssample_test_ko_TW", function() {
+    test("jsuniv_test_ko_TW", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"ko-TW",
@@ -84,7 +84,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("TV On Screen").toString()).toBe("기기 켜짐 화면");
     });
-    test("jssample_test_en_AU", function() {
+    test("jsuniv_test_en_AU", function() {
         expect.assertions(10);
 
         let rb = new ResBundle({
@@ -108,7 +108,7 @@ describe('test the localization result of webos-js app', () => {
         // multi-spaces
         expect(rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString()).toBe("Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.");
     });
-    test("jssample_test_en_GB", function() {
+    test("jsuniv_test_en_GB", function() {
         expect.assertions(10);
 
         let rb = new ResBundle({
@@ -132,7 +132,7 @@ describe('test the localization result of webos-js app', () => {
         // multi-spaces
         expect(rb.getString("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.").toString()).toBe("Go to 'Settings > General > Programmes > Programme Tuning & Settings > Transponder Edit' and add one.");
     });
-    test("jssample_test_fr_CA", function() {
+    test("jsuniv_test_fr_CA", function() {
         expect.assertions(5);
 
         let rb = new ResBundle({
@@ -148,7 +148,7 @@ describe('test the localization result of webos-js app', () => {
         fullPath = path.join(defaultRSPath, "fr/strings.json");
         expect(pluginUtils.isExistKey(fullPath, "Exit")).toBeTruthy();
     });
-    test("jssample_test_fr_FR", function() {
+    test("jsuniv_test_fr_FR", function() {
         expect.assertions(6);
         let rb = new ResBundle({
             locale:"fr-FR",
@@ -165,7 +165,7 @@ describe('test the localization result of webos-js app', () => {
         expect(pluginUtils.isExistKey(fullPath, "Exit")).toBeFalsy();
         
     });
-    test("jssample_test_es_ES", function() {
+    test("jsuniv_test_es_ES", function() {
         expect.assertions(4);
         let rb = new ResBundle({
             locale:"es-ES",
@@ -178,7 +178,7 @@ describe('test the localization result of webos-js app', () => {
         fullPath = path.join(defaultRSPath, "es/ES/strings.json");
         expect(pluginUtils.isExistKey(fullPath, "OK")).toBeTruthy();
     });
-    test("jssample_test_es_CO", function() {
+    test("jsuniv_test_es_CO", function() {
         expect.assertions(3);
         let rb = new ResBundle({
             locale:"es-CO",
@@ -188,7 +188,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("Sound Out").toString()).toBe("Salida de Audio");
         expect(rb.getString("OK").toString()).toBe("Aceptar"); // common data
     });
-    test("jssample_test_ja_JP", function() {
+    test("jsuniv_test_ja_JP", function() {
         expect.assertions(6);
 
         let rb = new ResBundle({
@@ -204,7 +204,7 @@ describe('test the localization result of webos-js app', () => {
         // fyi. https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/34
         expect(rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString()).toBe("利用規約を読むには、設定 > サポート > 利用規約 & 法的情報に移動します。");
     });
-    test("jssample_test_de_DE", function() {
+    test("jsuniv_test_de_DE", function() {
         expect.assertions(6);
         let rb = new ResBundle({
             locale:"de-DE",
@@ -217,7 +217,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("RETRY").toString()).toBe("WIEDERHOLEN");
         expect(rb.getString("SETTINGS").toString()).toBe("EINSTELLUNGEN");
     });
-    test("jssample_test_as_IN", function() {
+    test("jsuniv_test_as_IN", function() {
         expect.assertions(3);
         let rb = new ResBundle({
             locale:"as-IN",
@@ -228,7 +228,7 @@ describe('test the localization result of webos-js app', () => {
         expect(rb.getString("Restart").toString()).toBe("পুনৰাম্ভ কৰক");
     });
 
-    test("jssample_test_appinfo_locale_files", function() {
+    test("jsuniv_test_appinfo_locale_files", function() {
         expect.assertions(8);
 
         const asAppinfo = path.join(defaultRSPath, "as/appinfo.json");
@@ -246,7 +246,7 @@ describe('test the localization result of webos-js app', () => {
         expect(pluginUtils.loadData(koAppinfo)["title"]).toBe("현재 방송");
     });
 
-    test("jssample_test_appinfo_zxx_file_list", function() {
+    test("jsuniv_test_appinfo_zxx_file_list", function() {
         expect.assertions(1);
         const zxxPath = path.join(defaultRSPath, "zxx");
         const pseudoAppInfoFiles = [];
@@ -272,7 +272,7 @@ describe('test the localization result of webos-js app', () => {
         ]);
     });
 
-    test("jssample_test_appinfo_zxx_single_file_keys", function() {
+    test("jsuniv_test_appinfo_zxx_single_file_keys", function() {
         expect.assertions(2);
         const filePath = path.join(defaultRSPath, "zxx", "appinfo.json");
         expect(pluginUtils.isValidPath(filePath)).toBeTruthy();

--- a/packages/samples-loctool/webos-js-with-universal/test/JsUniversalApp.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsUniversalApp.test.js
@@ -1,7 +1,7 @@
 /*
  * JsUniversalApp.test.js - test the localization result of webos-js-with-universal app.
  *
- * Copyright (c) 2025-2026 JEDLSoft
+ * Copyright (c) 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/samples-loctool/webos-js-with-universal/test/JsUniversalAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsUniversalAppGenerate.test.js
@@ -1,7 +1,7 @@
 /*
  * JsUniversalAppGenerate.test.js - test the localization result in generate mode of webos-js app.
  *
- * Copyright (c) 2025-2026 JEDLSoft
+ * Copyright (c) 2026 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/samples-loctool/webos-js-with-universal/test/JsUniversalAppGenerate.test.js
+++ b/packages/samples-loctool/webos-js-with-universal/test/JsUniversalAppGenerate.test.js
@@ -1,5 +1,5 @@
 /*
- * JsAppGenerate.test.js - test the localization result in generate mode of webos-js app.
+ * JsUniversalAppGenerate.test.js - test the localization result in generate mode of webos-js app.
  *
  * Copyright (c) 2025-2026 JEDLSoft
  *
@@ -26,7 +26,7 @@ const { utils: pluginUtils } = require("ilib-loctool-webos-common");
 const ProjectFactory = require("loctool/lib/ProjectFactory.js");
 const GenerateModeProcess = require("loctool/lib/GenerateModeProcess.js");
 
-describe('test the localization result (generate mode) of webos-js app', () => {
+describe('test the localization result (generate mode) of webos-js-with-universal app', () => {
     beforeAll(async() => {
         const outputPath = "./resources2";
         if (fs.existsSync(outputPath)) {
@@ -74,7 +74,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         GenerateModeProcess(project);
 
     }, 50000);
-    test("jssample_generate_test_ko_KR", function() {
+    test("jsuniv_generate_test_ko_KR", function() {
         expect.assertions(8);
         let rb = new ResBundle({
             locale:"ko-KR",
@@ -91,7 +91,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         // common data
         expect(rb.getString("Please enter password.").toString()).toBe("Please enter password.");
     });
-    test("jssample_generate_test_ko_US", function() {
+    test("jsuniv_generate_test_ko_US", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"ko-US",
@@ -100,7 +100,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("Antenna NEXTGEN TV").toString()).toBe("안테나 NEXTGEN TV");
     });
-    test("jssample_test_ko_TW", function() {
+    test("jsuniv_test_ko_TW", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"ko-TW",
@@ -109,7 +109,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("TV On Screen").toString()).toBe("기기 켜짐 화면");
     })
-    test("jssample_generate_test_en_AU", function() {
+    test("jsuniv_generate_test_en_AU", function() {
         expect.assertions(7);
 
         let rb = new ResBundle({
@@ -126,7 +126,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
         expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
     });
-    test("jssample_generate_test_en_GB", function() {
+    test("jsuniv_generate_test_en_GB", function() {
         expect.assertions(7);
 
         let rb = new ResBundle({
@@ -143,7 +143,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(pluginUtils.isExistKey(fullPath, "Programme")).toBeTruthy();
         expect(pluginUtils.isExistKey(fullPath, "Ivory Coast")).toBeFalsy();
     });
-    test("jssample_generate_test_fr_CA", function() {
+    test("jsuniv_generate_test_fr_CA", function() {
         expect.assertions(3);
 
         let rb = new ResBundle({
@@ -154,7 +154,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb.getString("Agree").toString()).toBe("D’accord");
         expect(rb.getString("Programme").toString()).toBe("Programme");
     });
-    test("jssample_generate_test_fr_FR", function() {
+    test("jsuniv_generate_test_fr_FR", function() {
         expect.assertions(4);
         let rb = new ResBundle({
             locale:"fr-FR",
@@ -167,7 +167,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         let fullPath = path.join(defaultRSPath, "en/FR/strings.json");
         expect(pluginUtils.isExistKey(fullPath, "Others")).toBeFalsy();
     });
-    test("jssample_generate_test_es_ES", function() {
+    test("jsuniv_generate_test_es_ES", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"es-ES",
@@ -176,7 +176,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("Sound Out").toString()).toBe("Salida de sonido");
     });
-    test("jssample_generate_test_es_CO", function() {
+    test("jsuniv_generate_test_es_CO", function() {
         expect.assertions(2);
         let rb = new ResBundle({
             locale:"es-CO",
@@ -185,7 +185,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb).toBeTruthy();
         expect(rb.getString("Sound Out").toString()).toBe("Salida de Audio");
     });
-    test("jssample_generate_test_ja_JP", function() {
+    test("jsuniv_generate_test_ja_JP", function() {
         expect.assertions(5);
         let rb = new ResBundle({
             locale:"ja-JP",
@@ -198,7 +198,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
 
         expect(rb.getString("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.").toString()).toBe("To read the Terms and Conditions, go to Settings > Support >  Privacy & Terms.");
     });
-    test("jssample_generate_test_de_DE", function() {
+    test("jsuniv_generate_test_de_DE", function() {
         expect.assertions(6);
         let rb = new ResBundle({
             locale:"de-DE",
@@ -211,7 +211,7 @@ describe('test the localization result (generate mode) of webos-js app', () => {
         expect(rb.getString("RETRY").toString()).toBe("WIEDERHOLEN");
         expect(rb.getString("SETTINGS").toString()).toBe("EINSTELLUNGEN");
     });
-    test("jssample_generate_test_as_IN", function() {
+    test("jsuniv_generate_test_as_IN", function() {
         expect.assertions(3);
         let rb = new ResBundle({
             locale:"as-IN",

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/as-IN.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/as-IN.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="as-IN" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>RETRY</source>
+          <target>পুনৰ চেষ্টা</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Restart</source>
+          <target>পুনৰাম্ভ কৰক</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/de-DE.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/de-DE.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="de-DE" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>EXIT APP</source>
+          <target>APP BEENDEN</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Hello</source>
+          <target>Hallo</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>RETRY</source>
+          <target>WIEDERHOLEN</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Bye</source>
+          <target>Auf wiedersehen</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>SETTINGS</source>
+          <target>EINSTELLUNGEN</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/en-GB.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/en-GB.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-GB" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Rating Locks</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Postcode</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="5">
+         <segment>
+            <source>Go to  'Settings > General > Channels > Channel Tuning &amp; Settings > Transponder Edit' and add one.</source>
+            <target>Go to 'Settings > General > Programmes > Programme Tuning &amp; Settings > Transponder Edit' and add one.</target>
+          </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/en-US.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/en-US.xliff
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="en-US" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Channel</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>TV Name : </source>
+          <target>TV Name : </target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>TV Program Locks</source>
+          <target>TV Program Locks</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Service Area Zip Code</source>
+          <target>Service Area Zip Code</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/es-CO.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/es-CO.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-CO" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de Audio</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/es-ES.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/es-ES.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="es-ES" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Sound Out</source>
+          <target>Salida de sonido</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/fr-CA.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/fr-CA.xliff
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-CA" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>D’accord</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>Others</source>
+          <target>Autres</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/fr-FR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/fr-FR.xliff
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="fr-FR" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Ivory Coast</source>
+          <target>Côte d’Ivoire</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Programme</source>
+          <target>Programme</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Agree</source>
+          <target>J'accepte</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/ja-JP.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/ja-JP.xliff
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ja-JP" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Live TV</source>
+          <target>Live TV</target> <!-- NBSP 00a0 -->
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Space NBSP</source> <!-- source code doesn't have nbsp -->
+          <target>現実の時間とは異なり、</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>To read the Terms and Conditions, go to Settings > Support >  Privacy &amp; Terms.</source>
+          <target>利用規約を読むには、設定 > サポート > 利用規約 &amp; 法的情報に移動します。</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>MAC Address</source>
+          <target>MAC Address </target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>TV Name : </source>
+          <target>機器名：</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="sample-webos-js-with-universal_g2" name="x-json">
+      <unit id="200">
+        <segment>
+          <source>Live TV</source>
+          <target>Live TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/ko-KR.xliff
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>EXIT APP</source>
+          <target>앱 나가기</target>
+        </segment>
+      </unit>
+      <unit id="2">
+        <segment>
+          <source>Hello</source>
+          <target>안녕</target>
+        </segment>
+      </unit>
+      <unit id="3">
+        <segment>
+          <source>Thank you</source>
+          <target>고마워</target>
+        </segment>
+      </unit>
+      <unit id="4">
+        <segment>
+          <source>RETRY</source>
+          <target>재시도</target>
+        </segment>
+      </unit>
+      <unit id="5">
+        <segment>
+          <source>Bye</source>
+          <target>잘가</target>
+        </segment>
+      </unit>
+      <unit id="6">
+        <segment>
+          <source>SETTINGS</source>
+          <target>설정</target>
+        </segment>
+      </unit>
+      <unit id="7">
+        <segment>
+          <source>TV Name : </source>
+          <target>TV Name :</target>
+        </segment>
+      </unit>
+      <unit id="8">
+        <segment>
+          <source>Time Settings</source>
+          <target>[App] 시간 설정</target>
+        </segment>
+      </unit>
+      <unit id="9">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+      <unit id="10" name="volumeModeHigh">
+        <segment>
+          <source>High</source>
+          <target>높음</target>
+        </segment>
+      </unit>
+      <unit id="11">
+        <segment>
+          <source>High</source>
+          <target>최고</target>
+        </segment>
+      </unit>
+      <unit id="12">
+        <segment>
+          <source>TV On Screen</source>
+          <target>TV 켜짐 화면</target>
+        </segment>
+      </unit>
+      <unit id="177">
+        <segment>
+          <source>IPv6 e.g.: {ipAddress}</source>
+          <target>IPv6 예시: {ipAddress}</target>
+        </segment>
+      </unit>
+      <unit id="178">
+        <segment>
+          <source>IPv4 e.g.: {ip4Address}</source>
+          <target>IPv4 예시: {ip4Address}</target>
+        </segment>
+      </unit>
+    </group>
+    <group id="sample-webos-js-with-universal_g2" name="x-json">
+      <unit id="200">
+        <segment>
+          <source>Live TV</source>
+          <target>현재 방송</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/ko-KR.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/ko-KR.xliff
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-KR" version="2.0">
   <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g0" name="javascript">
+      <unit id="300">
+        <segment>
+          <source>Lookup Priority</source>
+          <target>우선순위(javascript)</target>
+        </segment>
+      </unit>
+    </group>
     <group id="sample-webos-js-with-universal_g1" name="universal">
       <unit id="1">
         <segment>
@@ -84,6 +92,12 @@
         <segment>
           <source>IPv4 e.g.: {ip4Address}</source>
           <target>IPv4 예시: {ip4Address}</target>
+        </segment>
+      </unit>
+      <unit id="179">
+        <segment>
+          <source>Lookup Priority</source>
+          <target>우선순위(universal)</target>
         </segment>
       </unit>
     </group>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/ko-TW.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/ko-TW.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-TW" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>TV On Screen</source>
+          <target>기기 켜짐 화면</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/packages/samples-loctool/webos-js-with-universal/xliffs/ko-US.xliff
+++ b/packages/samples-loctool/webos-js-with-universal/xliffs/ko-US.xliff
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-KR" trgLang="ko-US" version="2.0">
+  <file id="sample-webos-js-with-universal_f1" original="sample-webos-js-with-universal">
+    <group id="sample-webos-js-with-universal_g1" name="universal">
+      <unit id="1">
+        <segment>
+          <source>Antenna NEXTGEN TV</source>
+          <target>안테나 NEXTGEN TV</target>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,31 @@ importers:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
 
+  packages/samples-loctool/webos-js-with-universal:
+    dependencies:
+      ilib-loctool-webos-common:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-common
+      ilib-loctool-webos-javascript:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-javascript
+      ilib-loctool-webos-json:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json
+      ilib-loctool-webos-json-resource:
+        specifier: workspace:*
+        version: link:../../ilib-loctool-webos-json-resource
+      loctool:
+        specifier: ^2.33.1
+        version: 2.33.1
+    devDependencies:
+      ilib:
+        specifier: ^14.21.3
+        version: 14.22.0
+      jest:
+        specifier: ^30.3.0
+        version: 30.4.2(@types/node@12.20.55)(node-notifier@8.0.2)
+
   packages/samples-loctool/webos-json:
     dependencies:
       ilib-loctool-webos-common:


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
Add support for the universal datatype in the policy-based translation lookup, enabling a datatype-independent fallback within the current project before falling through to the common pool.

The `universal` datatype provides a datatype-independent translation fallback within the current project.
Unlike a self-type translation (e.g. javascript, c) which only matches its own file type,
universal translations are shared across all file type handlers within the same project.

This differs from `common`, which pulls translations from a separate shared project pool used across multiple projects.

- self type — file-type-specific translation within the current project (highest priority)
- universal — datatype-independent translation within the current project (medium priority)
- common — translation from the shared cross-project pool (lowest priority)

Full lookup order: self type → universal → common

#### Changes
ilib-loctool-webos-common
- buildPolicy() now accepts options.includeUniversal to prepend a universal lookup step.
- buildKey() handles the new "universal" entry

Plugins (c, cpp, dart, javascript)
- Enabled includeUniversal in each FileType.js

### Links
