### PR TITLE
Remove incorrect condition from codecov upload step

### DIFF
--- a/.github/workflows/_test-common.yml
+++ b/.github/workflows/_test-common.yml
@@ -67,7 +67,6 @@ jobs:
                   pnpm exec bats "$f"
                 done
             - name: Upload coverage to Codecov
-              if: hashFiles('coverage/**') != ''
               uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Checklist

* [ ] Pass the all tests.
* [ ] Include at least one test case for this feature or bug fix.
* [ ] Add a changeset for the changes.  
      If the changes are related to the loctool, make sure to update the changelog for `ilib‑loctool‑webos‑dist`.
* [ ] Add API documentation if necessary.

### Description
#### Problem
Since #114 (test workflow refactor), codecov report has not been generated on PRs. The **Upload coverage to Codecov** step in `_test-common.yml` was always skipped.
  
#### Cause
The condition `hashFiles('coverage/**')` looked for coverage files at the workspace root. In this monorepo, each package generates coverage under its own directory (e.g.  `packages/ilib-loctool-webos-common/coverage/`), so the glob never matched — causing the upload step to be skipped unconditionally.

#### Fix
Removed the if condition entirely. `codecov-action@v5` handles missing coverage files gracefully without failing the CI
(Verified #123 - not merged PR)